### PR TITLE
Tsn

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -974,8 +974,8 @@ class Installer:
 
 			self.pacman.strap('cronie')
 			self.pacman.strap('timeshift')
+			self.enable_service('cronie.service')
 
-		self.enable_service('cronie.service')
 		if bootloader and bootloader == Bootloader.Grub:
 			debug('Setting up grub integration for either')
 			self.pacman.strap('grub-btrfs')
@@ -1031,7 +1031,7 @@ class Installer:
 
 		debug('Configuring grub-btrfsd service for {snapshot_type} at {snapshot_path}')
 
-		# Works for either snapper or ts
+		# Works for either snapper or ts just adpating default paths above
 		# https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#id-1.14.3
 		systemd_dir = self.target / 'etc/systemd/system/grub-btrfsd.service.d'
 		systemd_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Tsn branch corrects snapper integration to point to expected path `/.snapshots` similar to how grub-timeshift is handled

Reduces friction as uses will only need to:

```
sudo snapper -c root create --description "something" 
grub-mkconfig -o /boot/grub/grub.cfg
```

Instead of having to configure manually:

`ExecStart=/usr/bin/grub-btrfsd --syslog {snapshot_path}`