### PR TITLE
User services

### DIFF
--- a/archinstoo/archinstoo/lib/models/__init__.py
+++ b/archinstoo/archinstoo/lib/models/__init__.py
@@ -31,6 +31,7 @@ from .mirrors import CustomRepository, MirrorRegion, PacmanConfiguration
 from .network import NetworkConfiguration, Nic, NicType
 from .packages import LocalPackage, PackageSearch, PackageSearchResult, Repository
 from .profile import ProfileConfiguration
+from .service import UserService
 from .users import PasswordStrength, User
 
 __all__ = [
@@ -77,5 +78,6 @@ __all__ = [
 	'SubvolumeModification',
 	'Unit',
 	'User',
+	'UserService',
 	'_DeviceInfo',
 ]

--- a/archinstoo/archinstoo/lib/models/service.py
+++ b/archinstoo/archinstoo/lib/models/service.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Self, TypedDict
+
+
+class UserServiceSerialization(TypedDict):
+	unit: str
+	user: str
+	linger: bool
+
+
+@dataclass(frozen=True)
+class UserService:
+	unit: str
+	user: str
+	linger: bool = False
+
+	def json(self) -> UserServiceSerialization:
+		return {
+			'unit': self.unit,
+			'user': self.user,
+			'linger': self.linger,
+		}
+
+	@classmethod
+	def parse_arg(cls, arg: dict[str, object]) -> Self:
+		return cls(
+			unit=str(arg['unit']),
+			user=str(arg['user']),
+			linger=bool(arg.get('linger', False)),
+		)

--- a/archinstoo/archinstoo/scripts/guided.py
+++ b/archinstoo/archinstoo/scripts/guided.py
@@ -166,7 +166,7 @@ def perform_installation(
 		# If the user provided a list of services to be enabled, pass the list to the enable_service function.
 		# Note that while it's called enable_service, it can actually take a list of services and iterate it.
 		if services := config.services:
-			installation.enable_service(services)
+			installation.enable_services_from_config(services)
 
 		if disk_config.has_default_btrfs_vols():
 			btrfs_options = disk_config.btrfs_options

--- a/archinstoo/archinstoo/scripts/guided.py
+++ b/archinstoo/archinstoo/scripts/guided.py
@@ -103,7 +103,7 @@ def perform_installation(
 		if config.swap and config.swap.enabled:
 			installation.setup_swap('zram', algo=config.swap.algorithm)
 
-		# Create users before applications (audio needs user for pipewire config)
+		# Create users before applications i.e audio needs user(s) for pipewire config
 		if config.auth_config and config.auth_config.users:
 			installation.create_users(
 				config.auth_config.users,
@@ -118,6 +118,14 @@ def perform_installation(
 
 		if config.bootloader_config and config.bootloader_config.bootloader != Bootloader.NO_BOOTLOADER:
 			installation.add_bootloader(config.bootloader_config.bootloader, config.bootloader_config.uki, config.bootloader_config.removable)
+
+		if disk_config.has_default_btrfs_vols():
+			btrfs_options = disk_config.btrfs_options
+			snapshot_config = btrfs_options.snapshot_config if btrfs_options else None
+			snapshot_type = snapshot_config.snapshot_type if snapshot_config else None
+			if snapshot_type:
+				bootloader = config.bootloader_config.bootloader if config.bootloader_config else None
+				installation.setup_btrfs_snapshot(snapshot_type, bootloader)
 
 		# If user selected to copy the current ISO network configuration
 		# Perform a copy of the config
@@ -143,6 +151,10 @@ def perform_installation(
 			if profile_config.profiles and DisplayServer.X11 in profile_config.display_servers() and locale_config:
 				installation.set_x11_keyboard(locale_config.kb_layout)
 
+		if (profile_config := config.profile_config) and profile_config.profiles:
+			for profile in profile_config.profiles:
+				profile.post_install(installation)
+
 		if config.packages and config.packages[0] != '':
 			installation.add_additional_packages(config.packages)
 
@@ -159,24 +171,14 @@ def perform_installation(
 			if config.auth_config.lock_root_account:
 				installation.lock_root_account()
 
-		if (profile_config := config.profile_config) and profile_config.profiles:
-			for profile in profile_config.profiles:
-				profile.post_install(installation)
+		# We run the next defs last because they might depend on anything above
 
-		# If the user provided a list of services to be enabled, pass the list to the enable_service function.
-		# Note that while it's called enable_service, it can actually take a list of services and iterate it.
+		# If the user provided a list of services to be enabled
+		# This might include system wide services or user specific
 		if services := config.services:
 			installation.enable_services_from_config(services)
 
-		if disk_config.has_default_btrfs_vols():
-			btrfs_options = disk_config.btrfs_options
-			snapshot_config = btrfs_options.snapshot_config if btrfs_options else None
-			snapshot_type = snapshot_config.snapshot_type if snapshot_config else None
-			if snapshot_type:
-				bootloader = config.bootloader_config.bootloader if config.bootloader_config else None
-				installation.setup_btrfs_snapshot(snapshot_type, bootloader)
-
-		# If the user provided custom commands to be run post-installation, execute them now.
+		# If the user provided custom commands to be run post-installation
 		if args.advanced and (cc := config.custom_commands):
 			run_custom_user_commands(cc, installation)
 

--- a/archinstoo/archinstoo/scripts/live.py
+++ b/archinstoo/archinstoo/scripts/live.py
@@ -147,7 +147,7 @@ def perform_installation(
 
 		# Services
 		if services := config.services:
-			installation.enable_service(services)
+			installation.enable_services_from_config(services)
 
 		# Custom commands
 		if args.advanced and (cc := config.custom_commands):

--- a/archinstoo/archinstoo/scripts/packages.py
+++ b/archinstoo/archinstoo/scripts/packages.py
@@ -79,7 +79,7 @@ def perform_installation(
 
 		# Services
 		if services := config.services:
-			installation.enable_service(services)
+			installation.enable_services_from_config(services)
 
 		elapsed_time = time.monotonic() - start_time
 		info(f'Package installation completed in {elapsed_time:.1f}s')

--- a/archinstoo/examples/config-sample-full.json
+++ b/archinstoo/examples/config-sample-full.json
@@ -187,15 +187,25 @@
     ],
     "kernel_headers": true,
     "profile_config": {
-        "profile": {
-            "main": "Desktop",
-            "details": [
-                "KDE Plasma"
-            ],
-            "custom_settings": {
-                "KDE Plasma": {}
+        "profiles": [
+            {
+                "main": "Desktop",
+                "details": [
+                    "KDE Plasma"
+                ],
+                "custom_settings": {
+                    "KDE Plasma": {}
+                }
+            },
+            {
+                "main": "Server",
+                "details": [
+                    "docker",
+                    "sshd"
+                ],
+                "custom_settings": {}
             }
-        },
+        ],
         "gfx_driver": "Intel (open-source)",
         "greeter": "gdm"
     },

--- a/archinstoo/examples/config-sample-full.json
+++ b/archinstoo/examples/config-sample-full.json
@@ -254,7 +254,10 @@
         "gnome-2048",
         "chromium"
     ],
-    "services": [],
+    "services": [
+        "sshd",
+        {"unit": "syncthing.service", "user": "myuser", "linger": true}
+    ],
     "custom_commands": [
         "#arch-chroot via bash tmp files # lines are ignored",
         "#ex: su - user -c \"bash ~/.stash/repo/install.sh\""

--- a/archinstoo/examples/config-sample-full.json
+++ b/archinstoo/examples/config-sample-full.json
@@ -261,7 +261,7 @@
     "timezone": "Europe/Berlin",
     "ntp": true,
     "packages": [
-        "gnome-2048",
+        "syncthing",
         "chromium"
     ],
     "services": [

--- a/archinstoo/tests/data/test_config.json
+++ b/archinstoo/tests/data/test_config.json
@@ -50,7 +50,8 @@
   },
   "services": [
     "service_1",
-    "service_2"
+    "service_2",
+    {"unit": "syncthing.service", "user": "testuser", "linger": true}
   ],
   "disk_config": {
     "config_type": "default_layout",

--- a/archinstoo/tests/test_args.py
+++ b/archinstoo/tests/test_args.py
@@ -32,6 +32,7 @@ from archinstoo.lib.models.locale import LocaleConfiguration
 from archinstoo.lib.models.mirrors import CustomRepository, CustomServer, MirrorRegion, PacmanConfiguration, SignCheck, SignOption
 from archinstoo.lib.models.network import NetworkConfiguration, Nic, NicType
 from archinstoo.lib.models.packages import Repository
+from archinstoo.lib.models.service import UserService
 from archinstoo.lib.models.users import Password, Shell, User
 from archinstoo.lib.translationhandler import translation_handler
 
@@ -213,6 +214,6 @@ def test_config_file_parsing(
 		packages=['firefox'],
 		swap=ZramConfiguration(enabled=False),
 		timezone='UTC',
-		services=['service_1', 'service_2'],
+		services=['service_1', 'service_2', UserService(unit='syncthing.service', user='testuser', linger=True)],
 		custom_commands=["echo 'Hello, World!'"],
 	)


### PR DESCRIPTION
This patch aims to introduce the behavior of https://wiki.archlinux.org/title/Systemd/User

So that you are free to configure services for a specific user instead of system wide. (This would better apply to certain servers profiles too, I'm guessing.)

```json
"sshd"
"syncthing@testuser.service"
{"unit": "syncthing.service", "user": "testuser", "linger": true}
```
Would achieve similar but give you more control over behavior. Also depending on if the packages are shipped with user unit/socket/timer or not this might be useful. 

