### PR TITLE
More encryption changes

### DIFF
--- a/archinstoo/archinstoo/lib/applications/cat/security.py
+++ b/archinstoo/archinstoo/lib/applications/cat/security.py
@@ -63,3 +63,11 @@ class SecurityApp:
 					debug('Installing security: Fail2ban')
 					install_session.add_additional_packages([tool.value])
 					install_session.enable_service('fail2ban.service')
+
+				case Security.LIBFIDO2:
+					debug('Installing security: libfido2')
+					install_session.add_additional_packages(['libfido2'])
+
+				case Security.SBCTL:
+					debug('Installing security: sbctl')
+					install_session.add_additional_packages(['sbctl'])

--- a/archinstoo/archinstoo/lib/applications/cat/security.py
+++ b/archinstoo/archinstoo/lib/applications/cat/security.py
@@ -64,9 +64,9 @@ class SecurityApp:
 					install_session.add_additional_packages([tool.value])
 					install_session.enable_service('fail2ban.service')
 
-				case Security.LIBFIDO2:
-					debug('Installing security: libfido2')
-					install_session.add_additional_packages(['libfido2'])
+				case Security.PAM_U2F:
+					debug('Installing security: pam-u2f')
+					install_session.add_additional_packages(['pam-u2f'])
 
 				case Security.SBCTL:
 					debug('Installing security: sbctl')

--- a/archinstoo/archinstoo/lib/disk/conf.py
+++ b/archinstoo/archinstoo/lib/disk/conf.py
@@ -229,6 +229,7 @@ def _boot_partition(sector_size: SectorSize, using_gpt: bool, using_subvolumes: 
 	start = Size(1, Unit.MiB, sector_size)
 
 	# mount ESP at /efi when using btrfs subvolumes so /boot stays in @
+	# for systemd-boot this also means UKI needs to be active (or would need a XBOOTLDR part)
 	mountpoint = Path('/efi') if using_subvolumes else Path('/boot')
 
 	return PartitionModification(

--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -18,6 +18,7 @@ from archinstoo.lib.models.device import (
 	DiskEncryption,
 	FilesystemType,
 	LsblkInfo,
+	LuksPbkdf,
 	LvmGroupInfo,
 	LvmPVInfo,
 	LvmVolume,
@@ -298,6 +299,7 @@ class DeviceHandler:
 		lock_after_create: bool = True,
 		iter_time: int = DEFAULT_ITER_TIME,
 		pbkdf_memory: int | None = None,
+		pbkdf: LuksPbkdf = LuksPbkdf.Argon2id,
 	) -> Luks2:
 		luks_handler = Luks2(
 			dev_path,
@@ -305,7 +307,7 @@ class DeviceHandler:
 			password=enc_password,
 		)
 
-		key_file = luks_handler.encrypt(iter_time=iter_time, pbkdf_memory=pbkdf_memory)
+		key_file = luks_handler.encrypt(iter_time=iter_time, pbkdf_memory=pbkdf_memory, pbkdf=pbkdf)
 
 		self.udev_sync()
 
@@ -338,7 +340,7 @@ class DeviceHandler:
 			password=enc_conf.encryption_password,
 		)
 
-		key_file = luks_handler.encrypt(iter_time=iter_time or enc_conf.iter_time, pbkdf_memory=pbkdf_memory)
+		key_file = luks_handler.encrypt(iter_time=iter_time or enc_conf.iter_time, pbkdf_memory=pbkdf_memory, pbkdf=enc_conf.pbkdf)
 
 		self.udev_sync()
 

--- a/archinstoo/archinstoo/lib/disk/disk_menu.py
+++ b/archinstoo/archinstoo/lib/disk/disk_menu.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import override
 
 from archinstoo.lib.disk.encryption_menu import DiskEncryptionMenu
@@ -132,7 +133,9 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		if not DiskEncryption.validate_enc(modifications, lvm_config):
 			return None
 
-		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=self._allow_auto_unlock).run()
+		allow_auto_unlock = self._allow_auto_unlock and any(p.is_efi() and p.mountpoint == Path('/efi') for mod in modifications for p in mod.partitions)
+
+		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=allow_auto_unlock).run()
 
 	def _select_disk_layout_config(self, preset: DiskLayoutConfiguration | None) -> DiskLayoutConfiguration | None:
 		disk_config = select_disk_config(preset)

--- a/archinstoo/archinstoo/lib/disk/disk_menu.py
+++ b/archinstoo/archinstoo/lib/disk/disk_menu.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 from typing import override
 
 from archinstoo.lib.disk.encryption_menu import DiskEncryptionMenu
@@ -133,7 +132,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		if not DiskEncryption.validate_enc(modifications, lvm_config):
 			return None
 
-		allow_auto_unlock = self._allow_auto_unlock and any(p.is_efi() and p.mountpoint == Path('/efi') for mod in modifications for p in mod.partitions)
+		allow_auto_unlock = self._allow_auto_unlock and any(p.is_boot() for mod in modifications for p in mod.partitions)
 
 		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=allow_auto_unlock).run()
 

--- a/archinstoo/archinstoo/lib/disk/disk_menu.py
+++ b/archinstoo/archinstoo/lib/disk/disk_menu.py
@@ -33,7 +33,8 @@ class DiskMenuConfig:
 
 
 class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
-	def __init__(self, disk_layout_config: DiskLayoutConfiguration | None):
+	def __init__(self, disk_layout_config: DiskLayoutConfiguration | None, allow_auto_unlock: bool = False):
+		self._allow_auto_unlock = allow_auto_unlock
 		if not disk_layout_config:
 			self._disk_menu_config = DiskMenuConfig(
 				disk_config=None,
@@ -131,7 +132,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		if not DiskEncryption.validate_enc(modifications, lvm_config):
 			return None
 
-		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset).run()
+		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=self._allow_auto_unlock).run()
 
 	def _select_disk_layout_config(self, preset: DiskLayoutConfiguration | None) -> DiskLayoutConfiguration | None:
 		disk_config = select_disk_config(preset)

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -101,10 +101,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				text=tr('Auto unlock root'),
 				action=self._select_auto_unlock_root,
 				value=self._enc_config.auto_unlock_root,
-				dependencies=[self._check_dep_enc_type],
+				dependencies=[self._check_dep_auto_unlock],
 				preview_action=self._preview,
 				key='auto_unlock_root',
-				enabled=self._allow_auto_unlock,
 			),
 		]
 
@@ -148,6 +147,12 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 	def _check_dep_lvm_vols(self) -> bool:
 		enc_type: EncryptionType | None = self._item_group.find_by_key('encryption_type').value
 		return bool(enc_type and enc_type == EncryptionType.LuksOnLvm)
+
+	def _check_dep_auto_unlock(self) -> bool:
+		if not self._allow_auto_unlock or not self._check_dep_enc_type():
+			return False
+		partitions: list[PartitionModification] | None = self._item_group.find_by_key('partitions').value
+		return bool(partitions and any(p.is_boot() for p in partitions))
 
 	@override
 	def run(self, additional_title: str | None = None) -> DiskEncryption | None:

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -98,7 +98,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				key='lvm_volumes',
 			),
 			MenuItem(
-				text=tr('Single password on boot'),
+				text=tr('Auto unlock root'),
 				action=self._select_auto_unlock_root,
 				value=self._enc_config.auto_unlock_root,
 				dependencies=[self._check_dep_enc_type],
@@ -114,8 +114,8 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		return []
 
 	def _select_auto_unlock_root(self, preset: bool) -> bool:
-		prompt = tr('Embed a keyfile in initramfs so root is auto-unlocked after GRUB decrypts /boot?') + '\n'
-		prompt += tr('This avoids entering the encryption password twice on boot.') + '\n'
+		prompt = tr('Embed a keyfile in initramfs so root is auto-unlocked ?') + '\n'
+		prompt += tr('This avoids entering encryption password twice on boot.') + '\n'
 
 		group = MenuItemGroup.yes_no()
 		group.set_focus_by_value(preset)
@@ -269,7 +269,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if enc_type and enc_type != EncryptionType.NoEncryption:
 			status = tr('Enabled') if auto_unlock else tr('Disabled')
-			return f'{tr("Single password on boot")}: {status}'
+			return f'{tr("Auto unlock root")}: {status}'
 
 		return None
 

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -7,6 +7,7 @@ from archinstoo.lib.models.device import (
 	DeviceModification,
 	DiskEncryption,
 	EncryptionType,
+	LuksPbkdf,
 	LvmConfiguration,
 	LvmVolume,
 	PartitionModification,
@@ -18,7 +19,7 @@ from archinstoo.lib.tui.curses_menu import EditMenu, SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
 from archinstoo.lib.tui.prompts import get_password
 from archinstoo.lib.tui.result import ResultType
-from archinstoo.lib.tui.types import Alignment, FrameProperties
+from archinstoo.lib.tui.types import Alignment, FrameProperties, Orientation
 
 
 class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
@@ -27,6 +28,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		device_modifications: list[DeviceModification],
 		lvm_config: LvmConfiguration | None = None,
 		preset: DiskEncryption | None = None,
+		allow_auto_unlock: bool = False,
 	):
 		if preset:
 			self._enc_config = preset
@@ -35,6 +37,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		self._device_modifications = device_modifications
 		self._lvm_config = lvm_config
+		self._allow_auto_unlock = allow_auto_unlock
 
 		menu_options = self._define_menu_options()
 		self._item_group = MenuItemGroup(menu_options, sort_items=False, checkmarks=True)
@@ -63,6 +66,14 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				key='encryption_password',
 			),
 			MenuItem(
+				text=tr('Key derivation function'),
+				action=select_pbkdf,
+				value=self._enc_config.pbkdf,
+				dependencies=[self._check_dep_enc_type],
+				preview_action=self._preview,
+				key='pbkdf',
+			),
+			MenuItem(
 				text=tr('Iteration time'),
 				action=select_iteration_time,
 				value=self._enc_config.iter_time,
@@ -86,12 +97,45 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				preview_action=self._preview,
 				key='lvm_volumes',
 			),
+			MenuItem(
+				text=tr('Single password on boot'),
+				action=self._select_auto_unlock_root,
+				value=self._enc_config.auto_unlock_root,
+				dependencies=[self._check_dep_enc_type],
+				preview_action=self._preview,
+				key='auto_unlock_root',
+				enabled=self._allow_auto_unlock,
+			),
 		]
 
 	def _select_lvm_vols(self, preset: list[LvmVolume]) -> list[LvmVolume]:
 		if self._lvm_config:
 			return select_lvm_vols_to_encrypt(self._lvm_config, preset=preset)
 		return []
+
+	def _select_auto_unlock_root(self, preset: bool) -> bool:
+		prompt = tr('Embed a keyfile in initramfs so root is auto-unlocked after GRUB decrypts /boot?') + '\n'
+		prompt += tr('This avoids entering the encryption password twice on boot.') + '\n'
+
+		group = MenuItemGroup.yes_no()
+		group.set_focus_by_value(preset)
+
+		result = SelectMenu[bool](
+			group,
+			header=prompt,
+			columns=2,
+			orientation=Orientation.HORIZONTAL,
+			alignment=Alignment.CENTER,
+			allow_skip=True,
+		).run()
+
+		match result.type_:
+			case ResultType.Skip:
+				return preset
+			case ResultType.Selection:
+				return result.item() == MenuItem.yes()
+			case _:
+				return preset
 
 	def _check_dep_enc_type(self) -> bool:
 		enc_type: EncryptionType | None = self._item_group.find_by_key('encryption_type').value
@@ -111,9 +155,11 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		enc_type: EncryptionType | None = self._item_group.find_by_key('encryption_type').value
 		enc_password: Password | None = self._item_group.find_by_key('encryption_password').value
+		pbkdf: LuksPbkdf | None = self._item_group.find_by_key('pbkdf').value
 		iter_time: int | None = self._item_group.find_by_key('iter_time').value
 		enc_partitions = self._item_group.find_by_key('partitions').value
 		enc_lvm_vols = self._item_group.find_by_key('lvm_volumes').value
+		auto_unlock_root: bool = self._item_group.find_by_key('auto_unlock_root').value or False
 
 		if enc_type is None or enc_partitions is None or enc_lvm_vols is None:
 			return None
@@ -131,6 +177,8 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				partitions=enc_partitions,
 				lvm_volumes=enc_lvm_vols,
 				iter_time=iter_time or DEFAULT_ITER_TIME,
+				pbkdf=pbkdf or LuksPbkdf.Argon2id,
+				auto_unlock_root=auto_unlock_root,
 			)
 
 		return None
@@ -144,6 +192,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		if (enc_pwd := self._prev_password()) is not None:
 			output += f'\n{enc_pwd}'
 
+		if (pbkdf := self._prev_pbkdf()) is not None:
+			output += f'\n{pbkdf}'
+
 		if (iter_time := self._prev_iter_time()) is not None:
 			output += f'\n{iter_time}'
 
@@ -152,6 +203,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if (lvm := self._prev_lvm_vols()) is not None:
 			output += f'\n\n{lvm}'
+
+		if (auto_unlock := self._prev_auto_unlock_root()) is not None:
+			output += f'\n{auto_unlock}'
 
 		if not output:
 			return None
@@ -191,12 +245,31 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		return None
 
+	def _prev_pbkdf(self) -> str | None:
+		pbkdf = self._item_group.find_by_key('pbkdf').value
+		enc_type = self._item_group.find_by_key('encryption_type').value
+
+		if pbkdf and enc_type != EncryptionType.NoEncryption:
+			return f'{tr("Key derivation function")}: {pbkdf.display_name()}'
+
+		return None
+
 	def _prev_iter_time(self) -> str | None:
 		iter_time = self._item_group.find_by_key('iter_time').value
 		enc_type = self._item_group.find_by_key('encryption_type').value
 
 		if iter_time and enc_type != EncryptionType.NoEncryption:
 			return f'{tr("Iteration time")}: {iter_time}ms'
+
+		return None
+
+	def _prev_auto_unlock_root(self) -> str | None:
+		auto_unlock = self._item_group.find_by_key('auto_unlock_root').value
+		enc_type = self._item_group.find_by_key('encryption_type').value
+
+		if enc_type and enc_type != EncryptionType.NoEncryption:
+			status = tr('Enabled') if auto_unlock else tr('Disabled')
+			return f'{tr("Single password on boot")}: {status}'
 
 		return None
 
@@ -304,6 +377,32 @@ def select_lvm_vols_to_encrypt(
 				return result.get_values()
 
 	return []
+
+
+def select_pbkdf(preset: LuksPbkdf | None = None) -> LuksPbkdf | None:
+	if not preset:
+		preset = LuksPbkdf.Argon2id
+
+	options = [LuksPbkdf.Argon2id, LuksPbkdf.Pbkdf2]
+	items = [MenuItem(o.display_name(), value=o) for o in options]
+	group = MenuItemGroup(items)
+	group.set_focus_by_value(preset.display_name())
+
+	result = SelectMenu[LuksPbkdf](
+		group,
+		allow_skip=True,
+		allow_reset=True,
+		alignment=Alignment.CENTER,
+		frame=FrameProperties.min(tr('Key derivation function')),
+	).run()
+
+	match result.type_:
+		case ResultType.Reset:
+			return None
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			return result.get_value()
 
 
 def select_iteration_time(preset: int | None = None) -> int | None:

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -637,6 +637,12 @@ class GlobalMenu(AbstractMenu[None]):
 			if any(p.is_boot() for p in enc.partitions):
 				return 'Encrypted /boot is only supported with GRUB'
 
+		# When ESP is at /efi with no separate /boot (e.g. btrfs subvolumes),
+		# systemd-boot has no partition to find the kernel/initramfs;
+		# either UKI must be enabled or a separate /boot (XBOOTLDR) is needed
+		if bootloader == Bootloader.Systemd and efi_partition and not boot_partition and not bootloader_config.uki:
+			return 'systemd-boot with ESP at /efi requires UKI or a separate /boot partition'
+
 		if bootloader == Bootloader.Limine:
 			limine_boot = boot_partition or efi_partition
 			if limine_boot is not None and limine_boot.fs_type not in [FilesystemType.Fat12, FilesystemType.Fat16, FilesystemType.Fat32]:

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -684,10 +684,8 @@ class GlobalMenu(AbstractMenu[None]):
 	) -> DiskLayoutConfiguration | None:
 		bootloader_config: BootloaderConfiguration | None = self._item_group.find_by_key('bootloader_config').value
 		uki_enabled = bool(bootloader_config and bootloader_config.uki)
-		is_grub = bool(bootloader_config and bootloader_config.bootloader == Bootloader.Grub)
-		# auto_unlock_root only works with GRUB (only bootloader that can decrypt /boot)
-		# and must not be used with UKI (initramfs on unencrypted ESP would expose the key)
-		allow_auto_unlock = is_grub and not uki_enabled
+		# UKI places the initramfs on the unencrypted ESP, which would expose the keyfile
+		allow_auto_unlock = not uki_enabled
 		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock).run()
 
 	def _select_bootloader_config(

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -235,9 +235,7 @@ class GlobalMenu(AbstractMenu[None]):
 		"""
 		Checks the validity of the current configuration.
 		"""
-		if len(self._missing_configs()) != 0:
-			return False
-		return self._validate_bootloader() is None
+		return not (self._missing_configs() or self._validate_bootloader())
 
 	def _select_archinstoo_settings(self, preset: Language) -> Language:
 		"""Open settings submenu for language and theme selection."""
@@ -580,28 +578,25 @@ class GlobalMenu(AbstractMenu[None]):
 			return bootloader_config.preview()
 		return None
 
-	def _validate_bootloader(self) -> str | None:
+	def _validate_bootloader(self) -> list[str]:
 		"""
 		Checks the selected bootloader is valid for the selected filesystem
 		type of the boot partition.
 
-		Returns [`None`] if the bootloader is valid, otherwise returns a
-		string with the error message.
-
-		XXX: The caller is responsible for wrapping the string with the translation
-			shim if necessary.
+		Returns a list of error messages, empty if the configuration is valid.
 		"""
-		bootloader_config: BootloaderConfiguration | None = None
+		errors: list[str] = []
+
+		bootloader_config: BootloaderConfiguration | None = self._item_group.find_by_key('bootloader_config').value
+
+		if not bootloader_config or bootloader_config.bootloader == Bootloader.NO_BOOTLOADER:
+			return errors
+
+		bootloader = bootloader_config.bootloader
+
 		root_partition: PartitionModification | None = None
 		boot_partition: PartitionModification | None = None
 		efi_partition: PartitionModification | None = None
-
-		bootloader_config = self._item_group.find_by_key('bootloader_config').value
-
-		if not bootloader_config or bootloader_config.bootloader == Bootloader.NO_BOOTLOADER:
-			return None
-
-		bootloader = bootloader_config.bootloader
 
 		if disk_config := self._item_group.find_by_key('disk_config').value:
 			for layout in disk_config.device_modifications:
@@ -615,55 +610,55 @@ class GlobalMenu(AbstractMenu[None]):
 					if efi_partition := layout.get_efi_partition():
 						break
 		else:
-			return 'No disk layout selected'
+			return ['No disk layout selected']
 
 		if root_partition is None:
-			return 'Root partition not found'
+			errors.append('Root partition not found')
 
 		# Legacy vs /efi newer standard
 		if SysInfo.has_uefi():
 			if efi_partition is None:
-				return 'EFI system partition (ESP) not found'
-
-			if efi_partition.fs_type not in [FilesystemType.Fat12, FilesystemType.Fat16, FilesystemType.Fat32]:
-				return 'ESP must be formatted as a FAT filesystem'
-		else:
-			# non-uefi needs /boot
-			if boot_partition is None:
-				return 'Boot partition not found'
+				errors.append('EFI system partition (ESP) not found')
+			elif efi_partition.fs_type not in [FilesystemType.Fat12, FilesystemType.Fat16, FilesystemType.Fat32]:
+				errors.append('ESP must be formatted as a FAT filesystem')
+		elif boot_partition is None:
+			errors.append('Boot partition not found')
 
 		if disk_config.disk_encryption and bootloader != Bootloader.Grub:
 			enc = disk_config.disk_encryption
 			if any(p.is_boot() for p in enc.partitions):
-				return 'Encrypted /boot is only supported with GRUB'
+				errors.append('Encrypted /boot is only supported with GRUB')
 
 		# When ESP is at /efi with no separate /boot (e.g. btrfs subvolumes),
 		# systemd-boot has no partition to find the kernel/initramfs;
 		# either UKI must be enabled or a separate /boot (XBOOTLDR) is needed
 		if bootloader == Bootloader.Systemd and efi_partition and not boot_partition and not bootloader_config.uki:
-			return 'systemd-boot with ESP at /efi requires UKI or a separate /boot partition'
+			errors.append('systemd-boot with ESP at /efi requires UKI or a separate XBOOTLDR /boot partition')
 
 		if bootloader == Bootloader.Limine:
 			limine_boot = boot_partition or efi_partition
 			if limine_boot is not None and limine_boot.fs_type not in [FilesystemType.Fat12, FilesystemType.Fat16, FilesystemType.Fat32]:
-				return 'Limine does not support booting with a non-FAT boot partition'
+				errors.append('Limine does not support booting with a non-FAT boot partition')
 
 		elif bootloader == Bootloader.Refind and not SysInfo.has_uefi():
-			return 'rEFInd can only be used on UEFI systems'
+			errors.append('rEFInd can only be used on UEFI systems')
 
-		return None
+		return errors
 
 	def _prev_install_invalid_config(self, item: MenuItem) -> str | None:
+		text = ''
+
 		if missing := self._missing_configs():
-			text = tr('Missing configurations:\n')
+			text += tr('Missing configurations:\n')
 			for m in missing:
 				text += f'- {m}\n'
-			return text[:-1]  # remove last new line
 
-		if error := self._validate_bootloader():
-			return tr(f'Invalid configuration: {error}')
+		if errors := self._validate_bootloader():
+			text += tr('Bad configurations:\n')
+			for e in errors:
+				text += f'- {e}\n'
 
-		return None
+		return text.rstrip('\n') or None
 
 	def _prev_profile(self, item: MenuItem) -> str | None:
 		profile_config: ProfileConfiguration | None = item.value

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -180,6 +180,7 @@ class GlobalMenu(AbstractMenu[None]):
 				action=select_aur_packages,
 				value=[],
 				preview_action=self._prev_aur_packages,
+				dependencies=[self._has_elevated_users],
 				key='aur_packages',
 			),
 			MenuItem(
@@ -202,6 +203,10 @@ class GlobalMenu(AbstractMenu[None]):
 			),
 		]
 
+	def _has_elevated_users(self) -> bool:
+		auth_config: AuthenticationConfiguration | None = self._item_group.find_by_key('auth_config').value
+		return auth_config.has_elevated_users if auth_config else False
+
 	def _missing_configs(self) -> list[str]:
 		item: MenuItem = self._item_group.find_by_key('auth_config')
 		auth_config: AuthenticationConfiguration | None = item.value
@@ -211,9 +216,8 @@ class GlobalMenu(AbstractMenu[None]):
 			return item.has_value()
 
 		missing = set()
-		has_superuser = auth_config.has_elevated_users if auth_config else False
 
-		if not self._skip_auth and (auth_config is None or auth_config.root_enc_password is None) and not has_superuser:
+		if not self._skip_auth and (auth_config is None or auth_config.root_enc_password is None) and not self._has_elevated_users():
 			missing.add(
 				tr('Either root-password or at least 1 user with elevated privileges must be specified'),
 			)

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -688,8 +688,10 @@ class GlobalMenu(AbstractMenu[None]):
 	) -> DiskLayoutConfiguration | None:
 		bootloader_config: BootloaderConfiguration | None = self._item_group.find_by_key('bootloader_config').value
 		uki_enabled = bool(bootloader_config and bootloader_config.uki)
-		# UKI places the initramfs on the unencrypted ESP, which would expose the keyfile
-		allow_auto_unlock = not uki_enabled
+		is_grub = bool(bootloader_config and bootloader_config.bootloader == Bootloader.Grub)
+		# Auto-unlock embeds a keyfile in the initramfs; only safe when /boot is encrypted,
+		# which only GRUB supports. UKI places initramfs on the unencrypted ESP.
+		allow_auto_unlock = is_grub and not uki_enabled
 		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock).run()
 
 	def _select_bootloader_config(

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -690,7 +690,7 @@ class GlobalMenu(AbstractMenu[None]):
 		uki_enabled = bool(bootloader_config and bootloader_config.uki)
 		is_grub = bool(bootloader_config and bootloader_config.bootloader == Bootloader.Grub)
 		# Auto-unlock embeds a keyfile in the initramfs; only safe when /boot is encrypted,
-		# which only GRUB supports. UKI places initramfs on the unencrypted ESP.
+		# which only GRUB supports. UKI should be off otherwise it will include the decryption key
 		allow_auto_unlock = is_grub and not uki_enabled
 		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock).run()
 

--- a/archinstoo/archinstoo/lib/grimaur.py
+++ b/archinstoo/archinstoo/lib/grimaur.py
@@ -153,7 +153,7 @@ def needs_elev(cmd: list[str]) -> list[str]:
 	return cmd
 
 
-class PacAurGitFpError(RuntimeError):
+class PacAurGitError(RuntimeError):
 	"""Wraps fatal errors coming from the helper."""
 
 
@@ -199,26 +199,26 @@ def aur_rpc_call(params: dict[str, Any]) -> dict[str, Any] | list[Any]:
 			status = response.getcode()
 			if status != 200:
 				disable_aur_rpc(f'status {status}')
-				raise PacAurGitFpError(f'AUR RPC request failed with status {status}')
+				raise PacAurGitError(f'AUR RPC request failed with status {status}')
 			payload = response.read()
 	except urllib.error.URLError as exc:
 		disable_aur_rpc(str(exc))
-		raise PacAurGitFpError(f'Failed to contact AUR RPC: {exc}') from exc
+		raise PacAurGitError(f'Failed to contact AUR RPC: {exc}') from exc
 	except Exception as exc:  # pragma: no cover - unexpected transport issues
 		disable_aur_rpc(str(exc))
-		raise PacAurGitFpError(f'Failed to contact AUR RPC: {exc}') from exc
+		raise PacAurGitError(f'Failed to contact AUR RPC: {exc}') from exc
 	try:
 		data = json.loads(payload.decode())
 	except (UnicodeDecodeError, json.JSONDecodeError) as exc:
 		disable_aur_rpc('invalid JSON payload')
-		raise PacAurGitFpError('Failed to decode AUR RPC response') from exc
+		raise PacAurGitError('Failed to decode AUR RPC response') from exc
 	# suggest endpoint returns a raw list, not a dict
 	if isinstance(data, list):
 		return data
 	if data.get('type') == 'error':
 		error_msg = str(data.get('error') or 'Unknown AUR RPC error')
 		disable_aur_rpc(error_msg)
-		raise PacAurGitFpError(error_msg)
+		raise PacAurGitError(error_msg)
 	return dict(data)
 
 
@@ -227,7 +227,7 @@ def aur_rpc_info(package: str) -> dict[str, Any] | None:
 		return _AUR_INFO_CACHE[package]
 	try:
 		data = aur_rpc_call({'type': 'info', 'arg[]': [package]})
-	except PacAurGitFpError:
+	except PacAurGitError:
 		_AUR_INFO_CACHE[package] = None
 		return None
 	if not isinstance(data, dict):
@@ -272,7 +272,7 @@ def dependency_set_from_rpc(info: dict[str, Any]) -> DependencySet:
 def aur_rpc_search_results(pattern: str) -> list[dict[str, Any]]:
 	try:
 		data = aur_rpc_call({'type': 'search', 'arg': pattern})
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return []
 	if not isinstance(data, dict):
 		return []
@@ -285,7 +285,7 @@ def aur_rpc_search_results(pattern: str) -> list[dict[str, Any]]:
 def aur_rpc_suggest(prefix: str) -> list[str]:
 	try:
 		data = aur_rpc_call({'type': 'suggest', 'arg': prefix})
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return []
 	# suggest endpoint returns a raw list of strings
 	if isinstance(data, list):
@@ -312,9 +312,9 @@ def run_command(
 			env=env,
 		)
 	except FileNotFoundError as exc:  # e.g. git not installed
-		raise PacAurGitFpError(f'Required command not found: {cmd[0]}') from exc
+		raise PacAurGitError(f'Required command not found: {cmd[0]}') from exc
 	except subprocess.CalledProcessError as exc:
-		raise PacAurGitFpError(f'Command failed with exit code {exc.returncode}: {" ".join(cmd)}\n{exc.stderr or ""}') from exc
+		raise PacAurGitError(f'Command failed with exit code {exc.returncode}: {" ".join(cmd)}\n{exc.stderr or ""}') from exc
 
 	if capture:
 		return completed.stdout
@@ -338,7 +338,7 @@ def ensure_clone(
 		if force_reclone:
 			shutil.rmtree(package_dir)
 		else:
-			raise PacAurGitFpError(f"Destination '{package_dir}' exists but is not a git repository. Use --force to overwrite.")
+			raise PacAurGitError(f"Destination '{package_dir}' exists but is not a git repository. Use --force to overwrite.")
 
 	if repo_url:
 		if package_dir.exists() and (package_dir / '.git').is_dir() and not force_reclone:
@@ -366,7 +366,7 @@ def ensure_clone(
 							f'origin/{package}',
 						),
 					)
-				except PacAurGitFpError:
+				except PacAurGitError:
 					if package_dir.exists():
 						shutil.rmtree(package_dir)
 					return ensure_clone(
@@ -387,7 +387,7 @@ def ensure_clone(
 				run_command(['git', '-C', str(package_dir), 'fetch', 'origin', branch_name])
 				try:
 					_reset_git_worktree(package_dir, (f'origin/{branch_name}',))
-				except PacAurGitFpError:
+				except PacAurGitError:
 					if package_dir.exists():
 						shutil.rmtree(package_dir)
 					return ensure_clone(
@@ -469,7 +469,7 @@ def parse_dependencies(srcinfo_content: str) -> tuple[str, str | None, Dependenc
 			checkdepends.update([_normalize_dep(value)])
 
 	if not pkgbase:
-		raise PacAurGitFpError('Failed to parse pkgbase from .SRCINFO')
+		raise PacAurGitError('Failed to parse pkgbase from .SRCINFO')
 	return (
 		pkgbase,
 		pkgdesc,
@@ -547,7 +547,7 @@ def _reset_git_worktree(package_dir: Path, refs: Sequence[str]) -> None:
 				],
 				capture=True,
 			)
-		except PacAurGitFpError:
+		except PacAurGitError:
 			continue
 		run_command(
 			[
@@ -560,7 +560,7 @@ def _reset_git_worktree(package_dir: Path, refs: Sequence[str]) -> None:
 			]
 		)
 		return
-	raise PacAurGitFpError(f'Could not reset {package_dir.name} to any of: {", ".join(refs)}')
+	raise PacAurGitError(f'Could not reset {package_dir.name} to any of: {", ".join(refs)}')
 
 
 def is_regex(pattern: str) -> bool:
@@ -604,7 +604,7 @@ def _pacman_returns_zero(args: Sequence[str]) -> bool:
 			check=False,
 		)
 	except FileNotFoundError as exc:
-		raise PacAurGitFpError('pacman command not found; this tool must run on Arch Linux') from exc
+		raise PacAurGitError('pacman command not found; this tool must run on Arch Linux') from exc
 	return proc.returncode == 0
 
 
@@ -639,7 +639,7 @@ def is_dependency_satisfied(dep: str) -> bool:
 			check=False,
 		)
 	except FileNotFoundError as exc:
-		raise PacAurGitFpError('pacman command not found; this tool must run on Arch Linux') from exc
+		raise PacAurGitError('pacman command not found; this tool must run on Arch Linux') from exc
 	return proc.returncode == 0
 
 
@@ -709,7 +709,7 @@ def _search_aur_candidates(dep: str, *, limit: int = 25) -> list[str]:
 				['git', 'ls-remote', '--heads', get_aur_remote(), pattern],
 				capture=True,
 			)
-		except PacAurGitFpError:
+		except PacAurGitError:
 			continue
 		for raw_line in str(output).splitlines():
 			parts = raw_line.split()
@@ -806,7 +806,7 @@ def resolve_official_dependency(dep: str) -> str | None:
 			],
 			capture=True,
 		)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return None
 	providers = [line.strip() for line in str(output).splitlines() if line.strip()]
 	if not providers:
@@ -834,7 +834,7 @@ def exists_in_aur_mirror(package: str) -> bool:
 			],
 			capture=True,
 		)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return False
 	return bool(str(output).strip())
 
@@ -842,7 +842,7 @@ def exists_in_aur_mirror(package: str) -> bool:
 def list_foreign_packages() -> dict[str, str]:
 	try:
 		output = run_command(['pacman', '-Qm'], capture=True, check=False)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return {}
 
 	names: dict[str, str] = {}
@@ -862,7 +862,7 @@ def get_local_head(package_dir: Path) -> str | None:
 		return None
 	try:
 		output = run_command(['git', '-C', str(package_dir), 'rev-parse', 'HEAD'], capture=True)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return None
 	return str(output).strip() or None
 
@@ -890,7 +890,7 @@ def get_remote_head(package: str) -> str | None:
 				],
 				capture=True,
 			)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return None
 	for line in str(output).splitlines():
 		parts = line.split()
@@ -905,7 +905,7 @@ def get_remote_head(package: str) -> str | None:
 def get_installed_version(package: str) -> str | None:
 	try:
 		output = run_command(['pacman', '-Qi', package], capture=True)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return None
 	for line in str(output).splitlines():
 		if line.lower().startswith('version'):
@@ -1058,7 +1058,7 @@ def collect_missing_official_packages(
 def build_and_install(package_dir: Path, *, noconfirm: bool, refresh: bool = False) -> None:
 	pkgbuild_path = package_dir / 'PKGBUILD'
 	if not pkgbuild_path.exists():
-		raise PacAurGitFpError(f'PKGBUILD missing at {pkgbuild_path}')
+		raise PacAurGitError(f'PKGBUILD missing at {pkgbuild_path}')
 	flags = '-sif' if refresh else '-si'
 	cmd = ['makepkg', flags, '--needed']
 	if noconfirm:
@@ -1105,11 +1105,11 @@ def install_package(
 			if is_installed(package):
 				print(f'Package {style(package, BOLD)} was installed as a split package')
 				return
-			raise PacAurGitFpError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
+			raise PacAurGitError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
 	elif USE_AUR_RPC:
 		info = aur_rpc_info(package)
 		if info is None and USE_AUR_RPC:
-			raise PacAurGitFpError(f"Package '{package}' not found via AUR RPC")
+			raise PacAurGitError(f"Package '{package}' not found via AUR RPC")
 	# Extract pkgbase for split packages (e.g., nvidia-580xx-dkms -> nvidia-580xx-utils)
 	pkgbase: str | None = None
 	if info:
@@ -1131,7 +1131,7 @@ def install_package(
 				if is_installed(package):
 					print(f'Package {style(package, BOLD)} was installed as a split package')
 					return
-				raise PacAurGitFpError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
+				raise PacAurGitError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
 		srcinfo = read_srcinfo(package_dir)
 		_, pkgdesc, deps = parse_dependencies(srcinfo)
 	if pkgdesc:
@@ -1165,7 +1165,7 @@ def install_package(
 
 	if unresolved:
 		missing_list = ', '.join(sorted(unresolved))
-		raise PacAurGitFpError(f'Could not resolve providers for: {missing_list}')
+		raise PacAurGitError(f'Could not resolve providers for: {missing_list}')
 
 	if missing_official:
 		to_install = missing_official - preinstalled_official
@@ -1183,7 +1183,7 @@ def install_package(
 			else:
 				print(f'  {dep_pkg}')
 		if not prompt_confirm(style('Proceed with building these dependencies? [y/N]: ', YELLOW)):
-			raise PacAurGitFpError('Installation aborted by user')
+			raise PacAurGitError('Installation aborted by user')
 
 	for aur_dep in sorted(aur_dependencies):
 		install_package(
@@ -1202,7 +1202,7 @@ def install_package(
 			if is_installed(package):
 				print(f'Package {style(package, BOLD)} was installed as a split package')
 				return
-			raise PacAurGitFpError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
+			raise PacAurGitError(f'PKGBUILD not found at {package_dir / "PKGBUILD"} - package may be a split package or have an invalid AUR entry')
 
 	build_and_install(package_dir, noconfirm=noconfirm, refresh=refresh)
 
@@ -1231,7 +1231,7 @@ def remove_package(
 		run_command(cmd)
 		invalidate_installed_cache()
 		print(f'Successfully removed {style(package, GREEN)}')
-	except PacAurGitFpError as exc:
+	except PacAurGitError as exc:
 		print(f'Failed to remove package: {exc}', file=sys.stderr)
 		return
 
@@ -1305,7 +1305,7 @@ def update_packages(
 		try:
 			run_command(cmd)
 			invalidate_installed_cache()
-		except PacAurGitFpError as exc:
+		except PacAurGitError as exc:
 			print(f'System update failed: {exc}', file=sys.stderr)
 			if not noconfirm and not prompt_confirm(style('Continue with AUR updates? [y/N]: ', YELLOW)):
 				return
@@ -1437,7 +1437,7 @@ def update_packages(
 				visited=shared_visited,
 				preinstalled_official=shared_preinstalled_official,
 			)
-		except PacAurGitFpError as exc:
+		except PacAurGitError as exc:
 			print(f'error updating {candidate.name}: {exc}', file=sys.stderr)
 
 	for package in missing:
@@ -1767,7 +1767,7 @@ def complete_packages_git(prefix: str, limit: int) -> list[str]:
 			['git', 'ls-remote', '--heads', get_aur_remote(), pattern],
 			capture=True,
 		)
-	except PacAurGitFpError:
+	except PacAurGitError:
 		return []
 	names: list[str] = []
 	for line in str(output).splitlines():
@@ -1847,13 +1847,13 @@ def inspect_package(
 					print('Optional: (none)')
 			return
 		if USE_AUR_RPC:
-			raise PacAurGitFpError(f"Package '{package}' not found via AUR RPC")
+			raise PacAurGitError(f"Package '{package}' not found via AUR RPC")
 
 	package_dir = ensure_clone(package, dest_root, refresh=refresh, repo_url=repo_url)
 	if target == 'PKGBUILD':
 		pkgbuild_path = package_dir / 'PKGBUILD'
 		if not pkgbuild_path.exists():
-			raise PacAurGitFpError(f'PKGBUILD not found at {pkgbuild_path}')
+			raise PacAurGitError(f'PKGBUILD not found at {pkgbuild_path}')
 		print(pkgbuild_path.read_text())
 		return
 	if target == 'SRCINFO':
@@ -2103,7 +2103,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 				)
 				if unresolved:
 					missing_list = ', '.join(sorted(unresolved))
-					raise PacAurGitFpError(f'Could not resolve providers for: {missing_list}')
+					raise PacAurGitError(f'Could not resolve providers for: {missing_list}')
 				if missing_official:
 					install_official_packages(
 						missing_official,
@@ -2193,7 +2193,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 						visited=shared_visited,
 						preinstalled_official=shared_preinstalled_official,
 					)
-				except PacAurGitFpError as exc:
+				except PacAurGitError as exc:
 					exit_code = 1
 					print(f'error installing {item.name}: {exc}', file=sys.stderr)
 			return exit_code
@@ -2219,7 +2219,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 			list_installed_packages()
 		else:
 			parser.error('Unknown command')
-	except PacAurGitFpError as exc:
+	except PacAurGitError as exc:
 		print(f'error: {exc}', file=sys.stderr)
 		return 1
 

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -1593,7 +1593,7 @@ class Installer:
 			loader = '/vmlinuz-{kernel}'
 
 			entries = (
-				'initrd=/initramfs-{kernel}.img',
+				'initrd=\\initramfs-{kernel}.img',
 				*self._get_kernel_params(root),
 			)
 

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -107,8 +107,7 @@ class Installer:
 		self._binaries: list[str] = []
 		self._files: list[str] = []
 
-		# systemd, sd-vconsole and sd-encrypt will be replaced by udev, keymap and encrypt
-		# if HSM is not used to encrypt the root volume. Check mkinitcpio() function for that override.
+		# sd-encrypt is inserted by _prepare_encrypt() when disk encryption is configured
 		self._hooks: list[str] = [
 			'base',
 			'systemd',
@@ -466,7 +465,7 @@ class Installer:
 							mapper_name=part_mod.mapper_name,
 							password=self._disk_encryption.encryption_password,
 						)
-						self._create_root_keyfile(luks_handler)
+						self._create_root_keyfile(luks_handler, mapper_name='cryptlvm')
 						break
 
 	def _generate_key_files_partitions(self) -> None:
@@ -509,20 +508,22 @@ class Installer:
 			if self._disk_encryption.auto_unlock_root and vol.is_root():
 				self._create_root_keyfile(luks_handler)
 
-	def _create_root_keyfile(self, luks_handler: Luks2) -> None:
-		# Create /crypto_keyfile.bin on target and add it as a LUKS key slot
-		# so the root volume can be auto-unlocked from the initramfs after GRUB
-		# decrypts /boot.
-		keyfile = self.target / 'crypto_keyfile.bin'
+	def _create_root_keyfile(self, luks_handler: Luks2, mapper_name: str = 'root') -> None:
+		"""Create a keyfile at the sd-encrypt standard path and add it as a LUKS
+		key slot so the volume can be auto-unlocked from the initramfs.
+		sd-encrypt auto-detects keys at /etc/cryptsetup-keys.d/<name>.key."""
+		kf_path = f'/etc/cryptsetup-keys.d/{mapper_name}.key'
+		keyfile = self.target / kf_path.lstrip('/')
 		debug(f'Creating root auto-unlock keyfile: {keyfile}')
 
+		keyfile.parent.mkdir(parents=True, exist_ok=True)
 		keyfile.write_bytes(os.urandom(2048))
 		keyfile.chmod(0o000)
 
 		luks_handler._add_key(keyfile)
 
-		if '/crypto_keyfile.bin' not in self._files:
-			self._files.append('/crypto_keyfile.bin')
+		if kf_path not in self._files:
+			self._files.append(kf_path)
 
 	def post_install_check(self, *args: str, **kwargs: str) -> list[str]:
 		return [step for step, flag in self._helper_flags.items() if flag is False]
@@ -821,12 +822,6 @@ class Installer:
 			content = re.sub('\nMODULES=(.*)', f'\nMODULES=({" ".join(self._modules)})', content)
 			content = re.sub('\nBINARIES=(.*)', f'\nBINARIES=({" ".join(self._binaries)})', content)
 			content = re.sub('\nFILES=(.*)', f'\nFILES=({" ".join(self._files)})', content)
-
-			# Use traditional encryption hooks for mkinitcpio
-			# * systemd -> udev
-			# * sd-vconsole -> keymap
-			self._hooks = [hook.replace('systemd', 'udev').replace('sd-vconsole', 'keymap consolefont') for hook in self._hooks]
-
 			content = re.sub('\nHOOKS=(.*)', f'\nHOOKS=({" ".join(self._hooks)})', content)
 			mkinit.seek(0)
 			mkinit.truncate()
@@ -862,8 +857,8 @@ class Installer:
 			self._hooks.remove('fsck')
 
 	def _prepare_encrypt(self, before: str = 'filesystems') -> None:
-		if 'encrypt' not in self._hooks:
-			self._hooks.insert(self._hooks.index(before), 'encrypt')
+		if 'sd-encrypt' not in self._hooks:
+			self._hooks.insert(self._hooks.index(before), 'sd-encrypt')
 
 	def minimal_installation(
 		self,
@@ -1094,18 +1089,8 @@ class Installer:
 		kernel_parameters = []
 
 		if root_partition in self._disk_encryption.partitions:
-			# TODO: We need to detect if the encrypted device is a whole disk encryption,
-			# or simply a partition encryption. Right now we assume it's a partition (and we always have)
-
-			if partuuid:
-				debug(f'Root partition is an encrypted device, identifying by PARTUUID: {root_partition.partuuid}')
-				kernel_parameters.append(f'cryptdevice=PARTUUID={root_partition.partuuid}:root')
-			else:
-				debug(f'Root partition is an encrypted device, identifying by UUID: {root_partition.uuid}')
-				kernel_parameters.append(f'cryptdevice=UUID={root_partition.uuid}:root')
-
-			if self._disk_encryption.auto_unlock_root:
-				kernel_parameters.append('cryptkey=rootfs:/crypto_keyfile.bin')
+			debug(f'Root partition is an encrypted device, identifying by UUID: {root_partition.uuid}')
+			kernel_parameters.append(f'rd.luks.name={root_partition.uuid}=root')
 
 			if id_root:
 				kernel_parameters.append('root=/dev/mapper/root')
@@ -1138,18 +1123,12 @@ class Installer:
 				uuid = self._get_luks_uuid_from_mapper_dev(pv_seg_info.pv_name)
 
 				debug(f'LvmOnLuks, encrypted root partition, identifying by UUID: {uuid}')
-				kernel_parameters.append(f'cryptdevice=UUID={uuid}:cryptlvm root={lvm.safe_dev_path}')
-
-				if self._disk_encryption.auto_unlock_root:
-					kernel_parameters.append('cryptkey=rootfs:/crypto_keyfile.bin')
+				kernel_parameters.append(f'rd.luks.name={uuid}=cryptlvm root={lvm.safe_dev_path}')
 			case EncryptionType.LuksOnLvm:
 				uuid = self._get_luks_uuid_from_mapper_dev(lvm.mapper_path)
 
 				debug(f'LuksOnLvm, encrypted root partition, identifying by UUID: {uuid}')
-				kernel_parameters.append(f'cryptdevice=UUID={uuid}:root root=/dev/mapper/root')
-
-				if self._disk_encryption.auto_unlock_root:
-					kernel_parameters.append('cryptkey=rootfs:/crypto_keyfile.bin')
+				kernel_parameters.append(f'rd.luks.name={uuid}=root root=/dev/mapper/root')
 			case EncryptionType.NoEncryption:
 				debug(f'Identifying root lvm by mapper device: {lvm.dev_path}')
 				kernel_parameters.append(f'root={lvm.safe_dev_path}')

--- a/archinstoo/archinstoo/lib/models/application.py
+++ b/archinstoo/archinstoo/lib/models/application.py
@@ -81,7 +81,7 @@ class Security(StrEnum):
 	FIREJAIL = auto()
 	BUBBLEWRAP = auto()
 	FAIL2BAN = auto()
-	LIBFIDO2 = auto()
+	PAM_U2F = 'pam-u2f'
 	SBCTL = auto()
 
 

--- a/archinstoo/archinstoo/lib/models/application.py
+++ b/archinstoo/archinstoo/lib/models/application.py
@@ -81,6 +81,8 @@ class Security(StrEnum):
 	FIREJAIL = auto()
 	BUBBLEWRAP = auto()
 	FAIL2BAN = auto()
+	LIBFIDO2 = auto()
+	SBCTL = auto()
 
 
 class SecurityConfigSerialization(TypedDict):

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -24,6 +24,18 @@ ENC_IDENTIFIER = 'ainst'
 DEFAULT_ITER_TIME = 10000
 
 
+class LuksPbkdf(Enum):
+	Argon2id = 'argon2id'
+	Pbkdf2 = 'pbkdf2'
+
+	def display_name(self) -> str:
+		match self:
+			case LuksPbkdf.Argon2id:
+				return 'Argon2id (Recommended)'
+			case LuksPbkdf.Pbkdf2:
+				return 'PBKDF2'
+
+
 class DiskLayoutType(Enum):
 	Default = 'default_layout'
 	Manual = 'manual_partitioning'
@@ -1428,6 +1440,8 @@ class DiskEncryption:
 	partitions: list[PartitionModification] = field(default_factory=list)
 	lvm_volumes: list[LvmVolume] = field(default_factory=list)
 	iter_time: int = DEFAULT_ITER_TIME
+	pbkdf: LuksPbkdf = LuksPbkdf.Argon2id
+	auto_unlock_root: bool = False
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.Luks, EncryptionType.LvmOnLuks] and not self.partitions:

--- a/archinstoo/archinstoo/lib/models/users.py
+++ b/archinstoo/archinstoo/lib/models/users.py
@@ -171,7 +171,7 @@ class User:
 	def json(self) -> UserSerialization:
 		return {
 			'username': self.username,
-			'enc_password': self.password.enc_password if self.password else None,
+			'enc_password': None,
 			'elev': self.elev,
 			'groups': self.groups,
 			'stash_urls': self.stash_urls,

--- a/archinstoo/archinstoo/schema.jsonc
+++ b/archinstoo/archinstoo/schema.jsonc
@@ -19,6 +19,7 @@
 
 	"filesystem_tools": {
 		// note most are handled by base (e2fsprogs, dosfstools)
+		// if not they are appended to base install
 		"btrfs": ["btrfs-progs"],
 		"xfs": ["xfsprogs"],
 		"f2fs": ["f2fs-tools"]
@@ -84,8 +85,8 @@
 		// -- Servers --
 		"Nginx": ["nginx"],
 		"Docker": ["docker"],
-		"httpd": ["apache"],
-		"sshd": ["openssh"],
+		"Httpd": ["apache"],
+		"Sshd": ["openssh"],
 		"Postgresql": ["postgresql"],
 		"Mariadb": ["mariadb"],
 		"Lighttpd": ["lighttpd"],
@@ -96,7 +97,8 @@
 	// profiles that need xorg-server/xorg-xinit when a gfx driver is selected
 	"xorg_profiles": ["Xfce4", "Cinnamon", "MATE", "Budgie", "LXQt", "Cutefish", "Deepin", "i3-wm", "Bspwm", "Awesome", "Enlightenment", "Qtile", "Xmonad"],
 
-	// each desktop specifies a default greeter but there is also Nogreeter type and can pick any
+	// each desktop specifies a default greeter 
+	// but there is also Nogreeter type and can pick any
 	"greeters": {
 		"lightdm-slick-greeter": ["lightdm", "lightdm-slick-greeter"],
 		"lightdm-gtk-greeter": ["lightdm", "lightdm-gtk-greeter"],
@@ -110,6 +112,7 @@
 	// this a 'advanced' option but seems to work fine
 	// run0 part of polkit/systemd
 	"privilege_escalation": {
+		"run0": ["polkit"],
 		"sudo": ["sudo"],
 		"doas": ["opendoas"]
 	},
@@ -169,7 +172,9 @@
 		"apparmor": ["apparmor"],
 		"firejail": ["firejail"],
 		"bubblewrap": ["bubblewrap"],
-		"fail2ban": ["fail2ban"]
+		"fail2ban": ["fail2ban"],
+		"pam_u2f": ["pam-u2f"],
+		"sbctl": ["sbctl"]
 	},
 
 	"network": {


### PR DESCRIPTION
This PR solves #84
And allows for `systemd` hooks instead of `busybox` + choice of `argon2id` or `pbkdf2`
It adds an option when no-`UKI` + `grub` and `/efi` is present

<img width="1320" height="244" alt="image" src="https://github.com/user-attachments/assets/cef847ed-4ffc-44ad-9552-5eca9d96a9eb" />

(Grimaur changes are unrelated)