### PR TITLE
patch `BIOS` paths to support `BIOS+GPT` partition layouts

### DIFF
--- a/archinstoo/archinstoo/lib/disk/conf.py
+++ b/archinstoo/archinstoo/lib/disk/conf.py
@@ -270,8 +270,13 @@ def _boot_partition(
 			)
 			start = Size(2, Unit.MiB, sector_size)
 
-		# BIOS: /boot — GRUB can read the user's chosen fs, Limine needs ext4
-		boot_fs = filesystem_type if bootloader == Bootloader.Grub else FilesystemType.Ext4
+		# BIOS: /boot — GRUB can read the user's chosen fs, Limine only supports FAT
+		if bootloader == Bootloader.Grub:
+			boot_fs = filesystem_type
+		elif bootloader == Bootloader.Limine:
+			boot_fs = FilesystemType.Fat32
+		else:
+			boot_fs = FilesystemType.Ext4
 		partitions.append(
 			PartitionModification(
 				status=ModificationStatus.Create,

--- a/archinstoo/archinstoo/lib/disk/conf.py
+++ b/archinstoo/archinstoo/lib/disk/conf.py
@@ -434,8 +434,6 @@ def suggest_single_disk_layout(
 	available_space = available_space.align()
 
 	# Used for reference: https://wiki.archlinux.org/title/partitioning
-
-	uefi = SysInfo.has_uefi()
 	boot_partitions = _boot_partition(sector_size, using_gpt, uefi, bootloader, using_subvolumes)
 	for part in boot_partitions:
 		device_modification.add_partition(part)

--- a/archinstoo/archinstoo/lib/disk/conf.py
+++ b/archinstoo/archinstoo/lib/disk/conf.py
@@ -271,12 +271,7 @@ def _boot_partition(
 			start = Size(2, Unit.MiB, sector_size)
 
 		# BIOS: /boot — GRUB can read the user's chosen fs, Limine only supports FAT
-		if bootloader == Bootloader.Grub:
-			boot_fs = filesystem_type
-		elif bootloader == Bootloader.Limine:
-			boot_fs = FilesystemType.Fat32
-		else:
-			boot_fs = FilesystemType.Ext4
+		boot_fs = FilesystemType.Fat32 if bootloader == Bootloader.Limine else filesystem_type
 		partitions.append(
 			PartitionModification(
 				status=ModificationStatus.Create,

--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -735,7 +735,7 @@ class DeviceHandler:
 		"""
 		Create a partition table on the block device and create all partitions.
 		"""
-		partition_table = partition_table or self.partition_table
+		partition_table = partition_table or modification.partition_table or self.partition_table
 
 		# WARNING: the entire device will be wiped and all data lost
 		if modification.wipe:

--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -587,8 +587,8 @@ class DeviceHandler:
 			length=length_sector.value,
 		)
 
-		fs_value = part_mod.safe_fs_type.parted_value
-		filesystem = FileSystem(type=fs_value, geometry=geometry)
+		fs_value = part_mod.fs_type.parted_value if part_mod.fs_type else None
+		filesystem = FileSystem(type=fs_value, geometry=geometry) if fs_value else None
 
 		partition = Partition(
 			disk=disk,

--- a/archinstoo/archinstoo/lib/disk/disk_menu.py
+++ b/archinstoo/archinstoo/lib/disk/disk_menu.py
@@ -3,6 +3,7 @@ from typing import override
 
 from archinstoo.lib.disk.encryption_menu import DiskEncryptionMenu
 from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
+from archinstoo.lib.models.bootloader import Bootloader
 from archinstoo.lib.models.device import (
 	DEFAULT_ITER_TIME,
 	BtrfsOptions,
@@ -33,8 +34,14 @@ class DiskMenuConfig:
 
 
 class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
-	def __init__(self, disk_layout_config: DiskLayoutConfiguration | None, allow_auto_unlock: bool = False):
+	def __init__(
+		self,
+		disk_layout_config: DiskLayoutConfiguration | None,
+		allow_auto_unlock: bool = False,
+		bootloader: Bootloader | None = None,
+	):
 		self._allow_auto_unlock = allow_auto_unlock
+		self._bootloader = bootloader
 		if not disk_layout_config:
 			self._disk_menu_config = DiskMenuConfig(
 				disk_config=None,
@@ -140,7 +147,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=allow_auto_unlock).run()
 
 	def _select_disk_layout_config(self, preset: DiskLayoutConfiguration | None) -> DiskLayoutConfiguration | None:
-		disk_config = select_disk_config(preset)
+		disk_config = select_disk_config(preset, bootloader=self._bootloader)
 
 		if disk_config != preset:
 			self._menu_item_group.find_by_key('lvm_config').value = None

--- a/archinstoo/archinstoo/lib/disk/filesystem.py
+++ b/archinstoo/archinstoo/lib/disk/filesystem.py
@@ -94,8 +94,8 @@ class FilesystemHandler:
 		the formatting functionality and in essence the support for the given filesystem.
 		"""
 
-		# don't touch existing partitions
-		create_or_modify_parts = [p for p in partitions if p.is_create_or_modify()]
+		# don't touch existing partitions or raw partitions (e.g. BIOS boot ef02)
+		create_or_modify_parts = [p for p in partitions if p.is_create_or_modify() and p.fs_type is not None]
 
 		self._validate_partitions(create_or_modify_parts)
 

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -695,7 +695,8 @@ class GlobalMenu(AbstractMenu[None]):
 		# from encrypted /boot, and UKI must be off otherwise the key
 		# ends up on the unencrypted ESP
 		allow_auto_unlock = is_grub and not uki_enabled
-		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock).run()
+		bootloader = bootloader_config.bootloader if bootloader_config else None
+		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock, bootloader=bootloader).run()
 
 	def _select_bootloader_config(
 		self,

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -760,6 +760,7 @@ class PartitionFlag(PartitionFlagDataMixin, Enum):
 	BOOT = parted.PARTITION_BOOT
 	XBOOTLDR = parted.PARTITION_BLS_BOOT, 'bls_boot'
 	ESP = parted.PARTITION_ESP
+	BIOS_GRUB = parted.PARTITION_BIOS_GRUB, 'bios_grub'
 	LINUX_HOME = parted.PARTITION_LINUX_HOME, 'linux-home'
 	SWAP = parted.PARTITION_SWAP
 

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -1371,6 +1371,7 @@ class DeviceModification:
 	device: BDevice
 	wipe: bool
 	partitions: list[PartitionModification] = field(default_factory=list)
+	partition_table: PartitionTable | None = None
 
 	@property
 	def device_path(self) -> Path:

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -1043,7 +1043,7 @@ class PartitionModification:
 			'Start': self.start.format_size(Unit.sectors, self.start.sector_size, include_unit=False),
 			'End': self.end.format_size(Unit.sectors, self.start.sector_size, include_unit=False),
 			'Size': self.length.format_highest(),
-			'FS type': self.fs_type.value if self.fs_type else 'Unknown',
+			'FS type': self.fs_type.value if self.fs_type else 'raw',
 			'Mountpoint': str(self.mountpoint) if self.mountpoint else '',
 			'Mount options': ', '.join(self.mount_options),
 			'Flags': ', '.join([f.description for f in self.flags]),

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -1043,7 +1043,7 @@ class PartitionModification:
 			'Start': self.start.format_size(Unit.sectors, self.start.sector_size, include_unit=False),
 			'End': self.end.format_size(Unit.sectors, self.start.sector_size, include_unit=False),
 			'Size': self.length.format_highest(),
-			'FS type': self.fs_type.value if self.fs_type else 'raw',
+			'FS type': self.fs_type.value if self.fs_type else 'Raw',
 			'Mountpoint': str(self.mountpoint) if self.mountpoint else '',
 			'Mount options': ', '.join(self.mount_options),
 			'Flags': ', '.join([f.description for f in self.flags]),


### PR DESCRIPTION
this adds a small selector in the menu for `mbr | gpt` when using `bios` hardware it would allow you to set up `GPT` partition tables as per:

https://wiki.archlinux.org/title/Limine#Supported_file_systems
https://wiki.archlinux.org/title/GRUB#GUID_Partition_Table_(GPT)_specific_instructions

`ef02` partition is only created for `GRUB` (since `Limine` uses the `MBR` gap).

Seems to work in QEMU/KVM but do not have any hardware to test this on 