### PR TITLE
Add support for `bcachefs` when using `--advanced`

### DIFF
--- a/ISOMOD
+++ b/ISOMOD
@@ -100,7 +100,28 @@ echo "Mod pkg list and MOTD..."
     echo "linux-headers"
     echo "bcachefs-dkms"
     echo "bcachefs-tools"
+    echo "dkms"
 } >> "$PROFILE_DIR/packages.x86_64"
+
+# Ensure bcachefs DKMS module is built and loaded at boot
+echo "Adding bcachefs DKMS boot service..."
+mkdir -p "$PROFILE_DIR/airootfs/etc/systemd/system/multi-user.target.wants"
+cat > "$PROFILE_DIR/airootfs/etc/systemd/system/bcachefs-dkms.service" << 'SVCEOF'
+[Unit]
+Description=Build and load bcachefs DKMS module
+After=local-fs.target
+ConditionPathExists=!/lib/modules/%v/updates/dkms/bcachefs.ko
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/dkms autoinstall
+ExecStart=/usr/sbin/modprobe bcachefs
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+ln -sf /etc/systemd/system/bcachefs-dkms.service "$PROFILE_DIR/airootfs/etc/systemd/system/multi-user.target.wants/bcachefs-dkms.service"
 
 # Append custom MOTD
 cat >> "$PROFILE_DIR/airootfs/etc/motd" << EOF

--- a/ISOMOD
+++ b/ISOMOD
@@ -96,6 +96,10 @@ find "$PROFILE_DIR/syslinux" -name "*.cfg" -exec sed -i 's|\(APPEND.*archiso.*\)
 echo "Mod pkg list and MOTD..."
 {
     echo "git"
+    # bcachefs support (removed from mainline kernel 6.18+, needs DKMS)
+    echo "linux-headers"
+    echo "bcachefs-dkms"
+    echo "bcachefs-tools"
 } >> "$PROFILE_DIR/packages.x86_64"
 
 # Append custom MOTD

--- a/archinstoo/archinstoo/lib/disk/conf.py
+++ b/archinstoo/archinstoo/lib/disk/conf.py
@@ -319,6 +319,7 @@ def select_main_filesystem_format(advanced: bool = False) -> FilesystemType:
 	]
 
 	if advanced:
+		items.append(MenuItem('bcachefs', value=FilesystemType.Bcachefs))
 		items.append(MenuItem('ntfs', value=FilesystemType.Ntfs))
 
 	group = MenuItemGroup(items, sort_items=False)

--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -475,7 +475,7 @@ class DeviceHandler:
 		# Parted does not have a file system type for bcachefs as of version 3.6, use
 		# ext4 in its place as that will result in a type of native Linux file system
 		if part_mod.fs_type == FilesystemType.Bcachefs:
-			fs_value = FilesystemType.Ext4.parted_value
+			fs_value: str | None = FilesystemType.Ext4.parted_value
 		else:
 			fs_value = part_mod.fs_type.parted_value if part_mod.fs_type else None
 		filesystem = FileSystem(type=fs_value, geometry=geometry) if fs_value else None

--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -245,6 +245,10 @@ class DeviceHandler:
 		options = []
 
 		match fs_type:
+			case FilesystemType.Bcachefs:
+				# bcachefs uses a different command structure
+				command = 'bcachefs'
+				options.append('format')
 			case FilesystemType.Btrfs | FilesystemType.Xfs:
 				# Force overwrite
 				options.append('-f')
@@ -468,7 +472,12 @@ class DeviceHandler:
 			length=length_sector.value,
 		)
 
-		fs_value = part_mod.fs_type.parted_value if part_mod.fs_type else None
+		# Parted does not have a file system type for bcachefs as of version 3.6, use
+		# ext4 in its place as that will result in a type of native Linux file system
+		if part_mod.fs_type == FilesystemType.Bcachefs:
+			fs_value = FilesystemType.Ext4.parted_value
+		else:
+			fs_value = part_mod.fs_type.parted_value if part_mod.fs_type else None
 		filesystem = FileSystem(type=fs_value, geometry=geometry) if fs_value else None
 
 		partition = Partition(

--- a/archinstoo/archinstoo/lib/disk/disk_menu.py
+++ b/archinstoo/archinstoo/lib/disk/disk_menu.py
@@ -39,9 +39,11 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		disk_layout_config: DiskLayoutConfiguration | None,
 		allow_auto_unlock: bool = False,
 		bootloader: Bootloader | None = None,
+		advanced: bool = False,
 	):
 		self._allow_auto_unlock = allow_auto_unlock
 		self._bootloader = bootloader
+		self._advanced = advanced
 		if not disk_layout_config:
 			self._disk_menu_config = DiskMenuConfig(
 				disk_config=None,
@@ -153,7 +155,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		return DiskEncryptionMenu(modifications, lvm_config=lvm_config, preset=preset, allow_auto_unlock=allow_auto_unlock).run()
 
 	def _select_disk_layout_config(self, preset: DiskLayoutConfiguration | None) -> DiskLayoutConfiguration | None:
-		disk_config = select_disk_config(preset, bootloader=self._bootloader)
+		disk_config = select_disk_config(preset, bootloader=self._bootloader, advanced=self._advanced)
 
 		if disk_config != preset:
 			self._menu_item_group.find_by_key('lvm_config').value = None
@@ -167,7 +169,7 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 		if not disk_config:
 			return preset
 
-		lvm_config = select_lvm_config(disk_config, preset=preset)
+		lvm_config = select_lvm_config(disk_config, preset=preset, advanced=self._advanced)
 
 		if lvm_config != preset:
 			self._menu_item_group.find_by_key('disk_encryption').value = None

--- a/archinstoo/archinstoo/lib/disk/partitioning_menu.py
+++ b/archinstoo/archinstoo/lib/disk/partitioning_menu.py
@@ -74,10 +74,12 @@ class PartitioningList(ListManager[DiskSegment]):
 		self,
 		device_mod: DeviceModification,
 		partition_table: PartitionTable,
+		advanced: bool = False,
 	) -> None:
 		device = device_mod.device
 
 		self._device = device
+		self._advanced = advanced
 		self._wipe = device_mod.wipe
 		self._buffer = Size(1, Unit.MiB, device.device_info.sector_size)
 		self._using_gpt = device_mod.using_gpt(partition_table)
@@ -590,14 +592,15 @@ class PartitioningList(ListManager[DiskSegment]):
 
 		from .conf import suggest_single_disk_layout
 
-		return suggest_single_disk_layout(self._device)
+		return suggest_single_disk_layout(self._device, advanced=self._advanced)
 
 
 def manual_partitioning(
 	device_mod: DeviceModification,
 	partition_table: PartitionTable,
+	advanced: bool = False,
 ) -> DeviceModification | None:
-	menu_list = PartitioningList(device_mod, partition_table)
+	menu_list = PartitioningList(device_mod, partition_table, advanced=advanced)
 	mod = menu_list.get_device_mod()
 
 	if menu_list.is_last_choice_reset():

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -47,10 +47,12 @@ class GlobalMenu(AbstractMenu[None]):
 		arch_config: ArchConfig,
 		skip_boot: bool = False,
 		skip_auth: bool = False,
+		advanced: bool = False,
 	) -> None:
 		self._arch_config = arch_config
 		self._skip_boot = skip_boot
 		self._skip_auth = skip_auth
+		self._advanced = advanced
 		self._uefi = SysInfo.has_uefi()
 		menu_options = self._get_menu_options()
 
@@ -696,7 +698,7 @@ class GlobalMenu(AbstractMenu[None]):
 		# ends up on the unencrypted ESP
 		allow_auto_unlock = is_grub and not uki_enabled
 		bootloader = bootloader_config.bootloader if bootloader_config else None
-		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock, bootloader=bootloader).run()
+		return DiskLayoutConfigurationMenu(preset, allow_auto_unlock=allow_auto_unlock, bootloader=bootloader, advanced=self._advanced).run()
 
 	def _select_bootloader_config(
 		self,

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -868,15 +868,11 @@ class Installer:
 		if fs_type.fs_type_mount in ('btrfs', 'bcachefs'):
 			self._disable_fstrim = True
 
-		if fs_type.fs_type_mount == 'bcachefs' and 'bcachefs' not in self._modules:
-			self._modules.append('bcachefs')
-
-		if fs_type.fs_type_mount == 'bcachefs' and 'bcachefs' not in self._hooks:
-			try:
-				block_index = self._hooks.index('block')
-				self._hooks.insert(block_index + 1, 'bcachefs')
-			except ValueError:
-				pass
+		if fs_type == FilesystemType.Bcachefs:
+			if 'bcachefs' not in self._modules:
+				self._modules.append('bcachefs')
+			if 'bcachefs' not in self._hooks and 'block' in self._hooks:
+				self._hooks.insert(self._hooks.index('block') + 1, 'bcachefs')
 
 		# There is not yet an fsck tool for NTFS. If it's being used for the root filesystem, the hook should be removed.
 		if fs_type.fs_type_mount == 'ntfs3' and mountpoint == self.target and 'fsck' in self._hooks:

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -384,7 +384,8 @@ class Installer:
 			options = list(part_mod.mount_options)
 
 			# restrict ESP permissions so bootctl doesn't warn about world-accessible seed files
-			if part_mod.is_efi() and part_mod.fs_type == FilesystemType.Fat32:
+			# only when mounted at /efi; at /boot the filesystem package expects 755
+			if part_mod.is_efi() and part_mod.fs_type == FilesystemType.Fat32 and part_mod.mountpoint != Path('/boot'):
 				for opt in ('fmask=0077', 'dmask=0077'):
 					if opt not in options:
 						options.append(opt)

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -793,6 +793,7 @@ class PartitionGUID(Enum):
 
 
 class FilesystemType(Enum):
+	Bcachefs = 'bcachefs'
 	Btrfs = 'btrfs'
 	Ext2 = 'ext2'
 	Ext3 = 'ext3'
@@ -829,6 +830,8 @@ class FilesystemType(Enum):
 	@property
 	def installation_pkg(self) -> str | None:
 		match self:
+			case FilesystemType.Bcachefs:
+				return 'bcachefs-tools'
 			case FilesystemType.Btrfs:
 				return 'btrfs-progs'
 			case FilesystemType.Xfs:

--- a/archinstoo/archinstoo/scripts/guided.py
+++ b/archinstoo/archinstoo/scripts/guided.py
@@ -28,7 +28,7 @@ from archinstoo.lib.tui import Tui
 
 def show_menu(config: ArchConfig, args: Arguments) -> None:
 	with Tui():
-		global_menu = GlobalMenu(config, args.skip_boot)
+		global_menu = GlobalMenu(config, args.skip_boot, advanced=args.advanced)
 
 		if not args.advanced:
 			global_menu.set_enabled('aur_packages', False)

--- a/archinstoo/archinstoo/scripts/live.py
+++ b/archinstoo/archinstoo/scripts/live.py
@@ -18,7 +18,7 @@ from archinstoo.lib.tui import Tui
 
 def show_menu(config: ArchConfig, args: Arguments) -> None:
 	with Tui():
-		global_menu = GlobalMenu(config, skip_boot=True, skip_auth=False)
+		global_menu = GlobalMenu(config, skip_boot=True, skip_auth=False, advanced=args.advanced)
 
 		# Disable items irrelevant for live mode
 		# We assume user built stage 1 but might still want to configure some stuff


### PR DESCRIPTION
This requires a custom ISO with more `cow_space` and `bcachefs` + tools `dkms` built

=> Use DI patterns to pass advanced to all related functions
=> Same as `btrfs` for `fstrim`
=> `ISOMOD` pre-build boot condition

Permissions on `/boot` regression from  0dbc7dbf