### PR TITLE
Allow TPM2 when detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A fork of `archinstall` with only `python-parted` as a dependency, many MORE choices, LESS packages installed in end-product, LESS complex flags, and MORE hot-fixes. *Aims to make the code base more readable, maintainable and modifiable by anyone*.
 
 > [!TIP]
-> In the [ISO](https://archlinux.org/download/), you are root by default and have some tools available. 
+> In the [ISO](https://archlinux.org/download/), you are root by default and have some tools available.
 > Use `sudo` or equivalent, *if running from an existing system. Here you will need more [dependencies](./archinstoo/PKGBUILD)*
 
 ## Setup / Usage
@@ -16,7 +16,7 @@ A fork of `archinstall` with only `python-parted` as a dependency, many MORE cho
 
 **0. Get internet access**
 > [!NOTE]
-> Ethernet cable is plug and play. 
+> Ethernet cable is plug and play.
 
 Test: `ping -c 3 google.com` if this returns `ttl=109 time=10.1 ms` 3 times...
 
@@ -73,7 +73,7 @@ To test fixes see: [Contributing](./.github/CONTRIBUTING.md)
 > You can create any profile in `archinstoo/default_profiles/` following convention, which will be imported automatically.
 Or modify existing ones direcly. Can also see here for [examples](./archinstoo/examples)
 
-You can make plugins easily `--script list` for `archinstoo`, anything inside `scripts/` is also imported. 
+You can make plugins easily `--script list` for `archinstoo`, anything inside `scripts/` is also imported.
 
 ```yaml
 Available options:
@@ -91,13 +91,13 @@ The full structure of the project can be consulted through [`TREE`](./archinstoo
 
 Core changes you can perform in `installer.py` and related defs (here search/find/replace is your friend).
 
-A `man` page is also available `man -l docs/archinstoo.1` 
+A `man` page is also available `man -l docs/archinstoo.1`
 
 ## Use cases
 
 See [Headless](./.github/HEADLESS.md) for example server install to play minecraft.
 
-See [Out-of-Tree](./.github/OUT_OF_TREE.md) for example install on unsupported hardware. *Uses a modified [`grimaur`](https://github.com/mackilanu/grimaur) during install* 
+See [Out-of-Tree](./.github/OUT_OF_TREE.md) for example install on unsupported hardware. *Uses a modified [`grimaur`](https://github.com/mackilanu/grimaur) during install*
 
 See [Multi-boot](./.github/MULTI_BOOT.md) for example to boot multiple OSes.
 
@@ -109,15 +109,17 @@ See [ARM-Support](./.github/ARM_SUPPORT.md) for example install on Raspi 5-b.
 
 ## Testing
 
-**Philosophy:** Simplify, No backwards-compat, Move fast. **Host-to-target** testing (without ISOs) [Philosophy](./.github/PHILOSOPHY.md).
+**Philosophy:** Simplify, No backwards-compat, Move fast. **Host-to-target** testing (without ISOs) [Philosophy](./.github/PHILOSOPHY.md)
 
-To see historical/latest changes [Changelog](./.github/CHANGELOG.md) and [Troubleshooting](./.github/TROUBLESHOOT.md) 
+To see historical/latest changes [Changelog](./.github/CHANGELOG.md) and [Troubleshooting](./.github/TROUBLESHOOT.md)
 
 The process would be the same with `git clone -b <branch> <url>` to test a specific fix.
 
-Usually reproduced then tested on actual/appropriate hardware. 
+Usually reproduced then tested on actual/appropriate hardware.
 
-Any help in this regard is deeply appreciated, as testing takes just as long if not longer than coding. 
+Any help in this regard is deeply appreciated, as testing takes just as long if not longer than coding.
+
+Accurate reports will be addressed in a timely manner: [Issues](https://github.com/h8d13/archinstoo/issues)
 
 ---
 

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -114,6 +114,14 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				preview_action=self._preview,
 				key='tpm2_unlock',
 			),
+			MenuItem(
+				text=tr('TPM2 PCRs'),
+				action=self._select_tpm2_pcrs,
+				value=self._enc_config.tpm2_pcrs,
+				dependencies=[self._check_dep_tpm2_pcrs],
+				preview_action=self._preview,
+				key='tpm2_pcrs',
+			),
 		]
 
 	def _select_lvm_vols(self, preset: list[LvmVolume]) -> list[LvmVolume]:
@@ -163,9 +171,48 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 	def _check_dep_tpm2(self) -> bool:
 		return SysInfo.has_tpm2() and self._check_dep_enc_type()
 
+	def _check_dep_tpm2_pcrs(self) -> bool:
+		return self._check_dep_tpm2() and bool(self._item_group.find_by_key('tpm2_unlock').value)
+
+	# Firmware-time PCRs are stable host->target so binding from the installer matches
+	# the target's first boot. OS-side PCRs need a different enrollment path that we do
+	# not ship from the installer.
+	_TPM2_PCR_OPTIONS: tuple[tuple[int, str], ...] = (
+		(0, 'Firmware executable code'),
+		(1, 'Firmware data / platform config'),
+		(2, 'Pluggable executable code (option ROMs)'),
+		(3, 'Pluggable firmware data'),
+		(7, 'Secure Boot state (PK/KEK/db/dbx, SBAT)'),
+	)
+
+	def _select_tpm2_pcrs(self, preset: str) -> str:
+		preset_pcrs = {int(p) for p in preset.split('+') if p.isdigit()} if preset else {0, 7}
+		valid_pcrs = {pcr for pcr, _ in self._TPM2_PCR_OPTIONS}
+
+		items = [MenuItem(text=f'PCR {pcr:>2} - {desc}', value=pcr) for pcr, desc in self._TPM2_PCR_OPTIONS]
+		group = MenuItemGroup(items)
+		group.set_selected_by_value([pcr for pcr in preset_pcrs if pcr in valid_pcrs])
+
+		result = SelectMenu[int](
+			group,
+			alignment=Alignment.CENTER,
+			multi=True,
+			allow_skip=True,
+			frame=FrameProperties.min(tr('TPM2 PCRs')),
+		).run()
+
+		match result.type_:
+			case ResultType.Skip:
+				return preset
+			case ResultType.Selection:
+				selected = sorted(result.get_values())
+				return '+'.join(str(p) for p in selected) if selected else preset
+			case _:
+				return preset
+
 	def _select_tpm2_unlock(self, preset: bool) -> bool:
 		prompt = tr('Bind a TPM2 keyslot to the LUKS device(s) so the disk auto-unlocks at boot ?') + '\n'
-		prompt += tr('Bound to PCR 0+7 (firmware + bootloader/secureboot state).') + '\n'
+		prompt += tr('PCR selection picked separately. Defaults to 0+7.') + '\n'
 		prompt += tr('Passphrase keyslot stays as fallback.') + '\n'
 
 		group = MenuItemGroup.yes_no()
@@ -200,6 +247,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		enc_lvm_vols = self._item_group.find_by_key('lvm_volumes').value
 		auto_unlock_root: bool = self._item_group.find_by_key('auto_unlock_root').value or False
 		tpm2_unlock: bool = self._item_group.find_by_key('tpm2_unlock').value or False
+		tpm2_pcrs: str = self._item_group.find_by_key('tpm2_pcrs').value or '0+7'
 
 		if enc_type is None or enc_partitions is None or enc_lvm_vols is None:
 			return None
@@ -220,6 +268,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				pbkdf=pbkdf or LuksPbkdf.Argon2id,
 				auto_unlock_root=auto_unlock_root,
 				tpm2_unlock=tpm2_unlock,
+				tpm2_pcrs=tpm2_pcrs,
 			)
 
 		return None
@@ -250,6 +299,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if (tpm2 := self._prev_tpm2_unlock()) is not None:
 			output += f'\n{tpm2}'
+
+		if (tpm2_pcrs := self._prev_tpm2_pcrs()) is not None:
+			output += f'\n{tpm2_pcrs}'
 
 		if not output:
 			return None
@@ -327,6 +379,12 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		tpm2 = self._item_group.find_by_key('tpm2_unlock').value
 		status = tr('Enabled') if tpm2 else tr('Disabled')
 		return f'{tr("TPM2 auto unlock")}: {status}'
+
+	def _prev_tpm2_pcrs(self) -> str | None:
+		if not self._item_group.find_by_key('tpm2_unlock').value:
+			return None
+		pcrs = self._item_group.find_by_key('tpm2_pcrs').value or '0+7'
+		return f'{tr("TPM2 PCRs")}: {pcrs}'
 
 
 def select_encryption_type(

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -1,6 +1,7 @@
 from typing import override
 
 from archinstoo.lib.authentication.password_prompt import get_password
+from archinstoo.lib.hardware import SysInfo
 from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
 from archinstoo.lib.menu.menu_helper import MenuHelper
 from archinstoo.lib.models.device import (
@@ -105,6 +106,14 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				preview_action=self._preview,
 				key='auto_unlock_root',
 			),
+			MenuItem(
+				text=tr('TPM2 auto unlock'),
+				action=self._select_tpm2_unlock,
+				value=self._enc_config.tpm2_unlock,
+				dependencies=[self._check_dep_tpm2],
+				preview_action=self._preview,
+				key='tpm2_unlock',
+			),
 		]
 
 	def _select_lvm_vols(self, preset: list[LvmVolume]) -> list[LvmVolume]:
@@ -151,6 +160,34 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 	def _check_dep_auto_unlock(self) -> bool:
 		return self._allow_auto_unlock and self._check_dep_enc_type()
 
+	def _check_dep_tpm2(self) -> bool:
+		return SysInfo.has_tpm2() and self._check_dep_enc_type()
+
+	def _select_tpm2_unlock(self, preset: bool) -> bool:
+		prompt = tr('Bind a TPM2 keyslot to the LUKS device(s) so the disk auto-unlocks at boot ?') + '\n'
+		prompt += tr('Bound to PCR 0+7 (firmware + bootloader/secureboot state).') + '\n'
+		prompt += tr('Passphrase keyslot stays as fallback.') + '\n'
+
+		group = MenuItemGroup.yes_no()
+		group.set_focus_by_value(preset)
+
+		result = SelectMenu[bool](
+			group,
+			header=prompt,
+			columns=2,
+			orientation=Orientation.HORIZONTAL,
+			alignment=Alignment.CENTER,
+			allow_skip=True,
+		).run()
+
+		match result.type_:
+			case ResultType.Skip:
+				return preset
+			case ResultType.Selection:
+				return result.item() == MenuItem.yes()
+			case _:
+				return preset
+
 	@override
 	def run(self, additional_title: str | None = None) -> DiskEncryption | None:
 		super().run(additional_title=additional_title)
@@ -162,6 +199,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		enc_partitions = self._item_group.find_by_key('partitions').value
 		enc_lvm_vols = self._item_group.find_by_key('lvm_volumes').value
 		auto_unlock_root: bool = self._item_group.find_by_key('auto_unlock_root').value or False
+		tpm2_unlock: bool = self._item_group.find_by_key('tpm2_unlock').value or False
 
 		if enc_type is None or enc_partitions is None or enc_lvm_vols is None:
 			return None
@@ -181,6 +219,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				iter_time=iter_time or DEFAULT_ITER_TIME,
 				pbkdf=pbkdf or LuksPbkdf.Argon2id,
 				auto_unlock_root=auto_unlock_root,
+				tpm2_unlock=tpm2_unlock,
 			)
 
 		return None
@@ -208,6 +247,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if (auto_unlock := self._prev_auto_unlock_root()) is not None:
 			output += f'\n{auto_unlock}'
+
+		if (tpm2 := self._prev_tpm2_unlock()) is not None:
+			output += f'\n{tpm2}'
 
 		if not output:
 			return None
@@ -274,6 +316,17 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 			return f'{tr("Auto unlock root")}: {status}'
 
 		return None
+
+	def _prev_tpm2_unlock(self) -> str | None:
+		enc_type = self._item_group.find_by_key('encryption_type').value
+		if not enc_type or enc_type == EncryptionType.NO_ENCRYPTION:
+			return None
+		if not SysInfo.has_tpm2():
+			return None
+
+		tpm2 = self._item_group.find_by_key('tpm2_unlock').value
+		status = tr('Enabled') if tpm2 else tr('Disabled')
+		return f'{tr("TPM2 auto unlock")}: {status}'
 
 
 def select_encryption_type(

--- a/archinstoo/archinstoo/lib/hardware.py
+++ b/archinstoo/archinstoo/lib/hardware.py
@@ -267,6 +267,22 @@ class SysInfo:
 		return _sys_info.has_uefi
 
 	@staticmethod
+	def has_tpm2() -> bool:
+		# Detects a TPM 2.0 chip via /sys/class/tpm/<dev>/tpm_version_major == 2.
+		# Filters out TPM 1.2 chips, which systemd-cryptenroll cannot bind to.
+		tpm_dir = Path('/sys/class/tpm')
+		if not tpm_dir.is_dir():
+			return False
+		for dev in tpm_dir.iterdir():
+			ver_file = dev / 'tpm_version_major'
+			try:
+				if ver_file.read_text().strip() == '2':
+					return True
+			except OSError:
+				continue
+		return False
+
+	@staticmethod
 	def _bitness() -> int | None:
 		return _sys_info.efi_bitness
 

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -549,6 +549,54 @@ class Installer:
 		if kf_path not in self._files:
 			self._files.append(kf_path)
 
+	def enroll_tpm2(self) -> None:
+		# Add a TPM2 keyslot to every encrypted device using systemd-cryptenroll.
+		# Requires systemd-cryptenroll in the chroot (provided by base/systemd) and a TPM 2.0
+		# device on the host. Existing passphrase keyslot remains as fallback.
+		if not self._disk_encryption.tpm2_unlock:
+			return
+		if self._disk_encryption.encryption_type == EncryptionType.NO_ENCRYPTION:
+			return
+		if not (password := self._disk_encryption.encryption_password):
+			warn('TPM2 enrollment skipped: no encryption password available')
+			return
+
+		devices: list[Path] = []
+		if self._disk_encryption.encryption_type in (EncryptionType.LUKS, EncryptionType.LVM_ON_LUKS):
+			devices.extend(p.safe_dev_path for p in self._disk_encryption.partitions)
+		elif self._disk_encryption.encryption_type == EncryptionType.LUKS_ON_LVM:
+			devices.extend(v.safe_dev_path for v in self._disk_encryption.lvm_volumes)
+
+		if not devices:
+			return
+
+		# /tmp keyfile inside the chroot — written without trailing newline so the
+		# whole file is treated as the passphrase by cryptenroll.
+		key_in_chroot = '/tmp/.luks_unlock_tpm2.key'
+		key_in_target = self.target / key_in_chroot.lstrip('/')
+
+		try:
+			key_in_target.write_bytes(password.plaintext.encode())
+			key_in_target.chmod(0o400)
+
+			for dev in devices:
+				info(f'Enrolling TPM2 keyslot for {dev}')
+				try:
+					self.arch_chroot(
+						[
+							'systemd-cryptenroll',
+							f'--unlock-key-file={key_in_chroot}',
+							'--tpm2-device=auto',
+							'--tpm2-pcrs=0+7',
+							str(dev),
+						]
+					)
+				except (SysCallError, CalledProcessError) as e:
+					warn(f'TPM2 enrollment failed for {dev}: {e}')
+		finally:
+			if key_in_target.exists():
+				key_in_target.unlink()
+
 	def post_install_check(self, *args: str, **kwargs: str) -> list[str]:
 		return [step for step, flag in self._helper_flags.items() if flag is False]
 
@@ -1218,6 +1266,9 @@ class Installer:
 		if self._zram_enabled:
 			kernel_parameters.append('zswap.enabled=0')
 
+		if self._disk_encryption.tpm2_unlock and self._disk_encryption.encryption_type != EncryptionType.NO_ENCRYPTION:
+			kernel_parameters.append('rd.luks.options=tpm2-device=auto')
+
 		if id_root:
 			for sub_vol in root.btrfs_subvols:
 				if sub_vol.is_root():
@@ -1879,6 +1930,9 @@ class Installer:
 		:param bootloader_removable: Whether to install to removable media location (UEFI only, for GRUB and Limine)
 		"""
 		self._flip_bmp(self.target / 'usr/share/systemd/bootctl/splash-arch.bmp')
+
+		# Run before bootloader install so kernel cmdline reflects rd.luks.options=tpm2-device=auto
+		self.enroll_tpm2()
 
 		efi_partition = self._get_efi_partition()
 		boot_partition = self._get_boot_partition()

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 
 from archinstoo.lib.disk.device_handler import DeviceHandler
 from archinstoo.lib.disk.lvm import lvm_import_vg, lvm_pvseg_info, lvm_vol_change
-from archinstoo.lib.disk.utils import get_lsblk_info, get_parent_device_path, mount, swapon, umount
+from archinstoo.lib.disk.utils import get_lsblk_info, get_parent_device_path, mount, swapon
 from archinstoo.lib.linux_path import LPath
 from archinstoo.lib.models.application import ZramAlgorithm
 from archinstoo.lib.models.device import (
@@ -207,7 +207,9 @@ class Installer:
 		# the outer ones that hold them. Failures propagate: we know exactly what we opened,
 		# so a failure here is a real bug, not best-effort cleanup.
 		info('Tearing down target mounts and mappings')
-		umount(self.target, recursive=True)
+		# Use `umount -R` directly: the disk.utils.umount helper expects a block device path
+		# and runs lsblk against it, which does not work for the target mountpoint root.
+		SysCommand(['umount', '-R', str(self.target)])
 
 		enc = self._disk_encryption
 		lvm_cfg = self._disk_config.lvm_config

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -612,6 +612,8 @@ class Installer:
 		if not devices:
 			return
 
+		pcrs = self._disk_encryption.tpm2_pcrs or '0+7'
+
 		# Stash the existing passphrase as a transient unlock keyfile under the standard
 		# LUKS keyfile dir (same convention as _create_root_keyfile).
 		key_in_chroot = '/etc/cryptsetup-keys.d/.tpm2-bootstrap.key'
@@ -623,14 +625,14 @@ class Installer:
 			key_in_target.chmod(0o400)
 
 			for dev in devices:
-				info(f'Enrolling TPM2 keyslot for {dev}')
+				info(f'Enrolling TPM2 keyslot for {dev} bound to PCR {pcrs}')
 				try:
 					self.arch_chroot(
 						[
 							'systemd-cryptenroll',
 							f'--unlock-key-file={key_in_chroot}',
 							'--tpm2-device=auto',
-							'--tpm2-pcrs=0+7',
+							f'--tpm2-pcrs={pcrs}',
 							str(dev),
 						]
 					)

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -637,7 +637,11 @@ class Installer:
 							str(dev),
 						]
 					)
-				except (SysCallError, CalledProcessError) as e:
+				except CalledProcessError as e:
+					stderr = e.stderr.decode(errors='replace').strip() if e.stderr else ''
+					stdout = e.stdout.decode(errors='replace').strip() if e.stdout else ''
+					warn(f'TPM2 enrollment failed for {dev} (exit {e.returncode}): {stderr or stdout or e}')
+				except SysCallError as e:
 					warn(f'TPM2 enrollment failed for {dev}: {e}')
 		finally:
 			if key_in_target.exists():

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -202,16 +202,9 @@ class Installer:
 			warn(f'Failed to sync install artifacts to target: {e}')
 
 	def _teardown_target(self) -> None:
-		# Reverse what we set up: unmount the target tree, deactivate VGs, close LUKS mappers.
-		# Order is encryption-topology dependent: close inner mappers before deactivating
-		# the outer ones that hold them. Failures propagate: we know exactly what we opened,
-		# so a failure here is a real bug, not best-effort cleanup.
+		# Order: unmount, deactivate VGs, close LUKS. Inner mappers close before the outer
+		# ones that hold them.
 		info('Tearing down target mounts and mappings')
-		# Use `umount -R` directly: the disk.utils.umount helper expects a block device path
-		# and runs lsblk against it, which does not work for the target mountpoint root.
-		# Fall back to lazy unmount if something (e.g. a leftover arch-chroot -S scope) is
-		# still holding the tree: lazy detaches the mounts so the underlying mappers can
-		# still be closed cleanly afterwards.
 		try:
 			SysCommand(['umount', '-R', str(self.target)])
 		except SysCallError:
@@ -619,13 +612,8 @@ class Installer:
 		if not devices:
 			return
 
-		# systemd ships systemd-cryptenroll, but TPM2 backend needs tpm2-tss at runtime.
-		# Bootloader install may pull it in later, but enrollment happens first.
-		self.pacman.strap('tpm2-tss')
-
 		# Stash the existing passphrase as a transient unlock keyfile under the standard
-		# LUKS keyfile dir (same convention as _create_root_keyfile). /tmp does not work:
-		# arch-chroot -S gives the chroot a private tmpfs that shadows host-written files.
+		# LUKS keyfile dir (same convention as _create_root_keyfile).
 		key_in_chroot = '/etc/cryptsetup-keys.d/.tpm2-bootstrap.key'
 		key_in_target = self.target / key_in_chroot.lstrip('/')
 		key_in_target.parent.mkdir(parents=True, exist_ok=True)

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 
 from archinstoo.lib.disk.device_handler import DeviceHandler
 from archinstoo.lib.disk.lvm import lvm_import_vg, lvm_pvseg_info, lvm_vol_change
-from archinstoo.lib.disk.utils import get_lsblk_info, get_parent_device_path, mount, swapon
+from archinstoo.lib.disk.utils import get_lsblk_info, get_parent_device_path, mount, swapon, umount
 from archinstoo.lib.linux_path import LPath
 from archinstoo.lib.models.application import ZramAlgorithm
 from archinstoo.lib.models.device import (
@@ -163,6 +163,7 @@ class Installer:
 		self._sync_artifacts_to_target()
 
 		if not (missing_steps := self.post_install_check()):
+			self._teardown_target()
 			msg = f'Installation completed without any errors.\nLog files temporarily available at {logger.directory}.\nYou may reboot when ready.\n'
 			log(msg, fg='green')
 
@@ -199,6 +200,45 @@ class Installer:
 				cfg_dst.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 		except Exception as e:
 			warn(f'Failed to sync install artifacts to target: {e}')
+
+	def _teardown_target(self) -> None:
+		# Reverse what we set up: unmount the target tree, deactivate VGs, close LUKS mappers.
+		# Order is encryption-topology dependent: close inner mappers before deactivating
+		# the outer ones that hold them. Failures propagate: we know exactly what we opened,
+		# so a failure here is a real bug, not best-effort cleanup.
+		info('Tearing down target mounts and mappings')
+		umount(self.target, recursive=True)
+
+		enc = self._disk_encryption
+		lvm_cfg = self._disk_config.lvm_config
+
+		def _close_luks(dev_path: Path, mapper_name: str | None) -> None:
+			if mapper_name is None:
+				return
+			Luks2(dev_path, mapper_name=mapper_name).lock()
+
+		def _deactivate_vgs() -> None:
+			if not lvm_cfg:
+				return
+			for vg in lvm_cfg.vol_groups:
+				self._device_handler.lvm_vg_deactivate(vg.name)
+
+		match enc.encryption_type:
+			case EncryptionType.LUKS_ON_LVM:
+				# LUKS sits on top of LVs, close LUKS first, then deactivate VGs.
+				for vol in enc.lvm_volumes:
+					_close_luks(vol.safe_dev_path, vol.mapper_name)
+				_deactivate_vgs()
+			case EncryptionType.LVM_ON_LUKS:
+				# VGs sit on LUKS PV, deactivate VGs first, then close LUKS.
+				_deactivate_vgs()
+				for part in enc.partitions:
+					_close_luks(part.safe_dev_path, part.mapper_name)
+			case EncryptionType.LUKS:
+				for part in enc.partitions:
+					_close_luks(part.safe_dev_path, part.mapper_name)
+			case EncryptionType.NO_ENCRYPTION:
+				_deactivate_vgs()
 
 	def _verify_service_stop(self) -> None:
 		# Check for essential services statuses based on

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -209,7 +209,14 @@ class Installer:
 		info('Tearing down target mounts and mappings')
 		# Use `umount -R` directly: the disk.utils.umount helper expects a block device path
 		# and runs lsblk against it, which does not work for the target mountpoint root.
-		SysCommand(['umount', '-R', str(self.target)])
+		# Fall back to lazy unmount if something (e.g. a leftover arch-chroot -S scope) is
+		# still holding the tree: lazy detaches the mounts so the underlying mappers can
+		# still be closed cleanly afterwards.
+		try:
+			SysCommand(['umount', '-R', str(self.target)])
+		except SysCallError:
+			warn(f'{self.target} busy, retrying with lazy unmount')
+			SysCommand(['umount', '-R', '-l', str(self.target)])
 
 		enc = self._disk_encryption
 		lvm_cfg = self._disk_config.lvm_config

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -623,10 +623,12 @@ class Installer:
 		# Bootloader install may pull it in later, but enrollment happens first.
 		self.pacman.strap('tpm2-tss')
 
-		# /tmp keyfile inside the chroot — written without trailing newline so the
-		# whole file is treated as the passphrase by cryptenroll.
-		key_in_chroot = '/tmp/.luks_unlock_tpm2.key'
+		# Stash the existing passphrase as a transient unlock keyfile under the standard
+		# LUKS keyfile dir (same convention as _create_root_keyfile). /tmp does not work:
+		# arch-chroot -S gives the chroot a private tmpfs that shadows host-written files.
+		key_in_chroot = '/etc/cryptsetup-keys.d/.tpm2-bootstrap.key'
 		key_in_target = self.target / key_in_chroot.lstrip('/')
+		key_in_target.parent.mkdir(parents=True, exist_ok=True)
 
 		try:
 			key_in_target.write_bytes(password.plaintext.encode())

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -570,6 +570,10 @@ class Installer:
 		if not devices:
 			return
 
+		# systemd ships systemd-cryptenroll, but TPM2 backend needs tpm2-tss at runtime.
+		# Bootloader install may pull it in later, but enrollment happens first.
+		self.pacman.strap('tpm2-tss')
+
 		# /tmp keyfile inside the chroot — written without trailing newline so the
 		# whole file is treated as the passphrase by cryptenroll.
 		key_in_chroot = '/tmp/.luks_unlock_tpm2.key'

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -1433,6 +1433,7 @@ class DiskEncryption:
 	pbkdf: LuksPbkdf = LuksPbkdf.Argon2id
 	auto_unlock_root: bool = False
 	tpm2_unlock: bool = False
+	tpm2_pcrs: str = '0+7'
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.LUKS, EncryptionType.LVM_ON_LUKS] and not self.partitions:

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -1432,6 +1432,7 @@ class DiskEncryption:
 	iter_time: int = DEFAULT_ITER_TIME
 	pbkdf: LuksPbkdf = LuksPbkdf.Argon2id
 	auto_unlock_root: bool = False
+	tpm2_unlock: bool = False
 
 	def __post_init__(self) -> None:
 		if self.encryption_type in [EncryptionType.LUKS, EncryptionType.LVM_ON_LUKS] and not self.partitions:


### PR DESCRIPTION
**Tests:** that removing TPM support on the board settings, triggers password prompt to come up again at boot.
Checks for specific TPM version 2. 

Binds to `PCR 0+7` by default and hold list of viable options `{0,1,2,3,7}`

https://systemd.io/TPM2_PCR_MEASUREMENTS/ 
https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/
https://github.com/systemd/systemd/pull/28891  

**Misc:** Add `_teardown_target` for cleanup

Related: 4461a9c3 db492d43

