### PR TITLE
Add ruff rules `TID251` and `ANN401`

### DIFF
--- a/archinstoo/archinstoo/lib/args.py
+++ b/archinstoo/archinstoo/lib/args.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass, field
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import Any, Self
 from urllib.request import Request, urlopen
 
 from archinstoo.lib.models.application import DEFAULT_KERNEL, ApplicationConfiguration, ZramConfiguration
@@ -321,7 +321,8 @@ class ArchConfigHandler:
 			try:
 				req = Request(url, headers={'User-Agent': 'ArchInstoo'})  # noqa: S310 - scheme restricted above
 				with urlopen(req) as resp:  # noqa: S310 - scheme restricted above
-					return cast('str', resp.read().decode('utf-8'))
+					content: str = resp.read().decode('utf-8')
+					return content
 			except urllib.error.HTTPError as err:
 				error(f'Could not fetch JSON from {url}: {err}')
 		else:

--- a/archinstoo/archinstoo/lib/configuration.py
+++ b/archinstoo/archinstoo/lib/configuration.py
@@ -1,6 +1,6 @@
 import json
 import stat
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from archinstoo.lib.translationhandler import tr
 from archinstoo.lib.tui.curses_menu import SelectMenu, Tui
@@ -90,7 +90,15 @@ class ConfigurationHandler:
 		try:
 			if config_file.exists():
 				with config_file.open() as f:
-					return cast('dict[str, Any]', json.load(f))
+					data = json.load(f)
+
+				# Validate at the boundary: valid JSON of the wrong type (list/scalar/null,
+				# or dict with non-str keys) must fail here, not mid-install downstream.
+				if not isinstance(data, dict) or not all(isinstance(k, str) for k in data):
+					warn(f'Ignoring saved config: expected a JSON object with string keys, got {type(data).__name__}')
+					return None
+
+				return data
 		except Exception as e:
 			warn(f'Failed to load saved config: {e}')
 		return None

--- a/archinstoo/archinstoo/lib/crypt.py
+++ b/archinstoo/archinstoo/lib/crypt.py
@@ -1,6 +1,5 @@
 import ctypes
 from pathlib import Path
-from typing import cast
 
 from archinstoo.lib.output import debug
 
@@ -33,12 +32,12 @@ def crypt_gen_salt(prefix: str | bytes, rounds: int) -> bytes:
 	if isinstance(prefix, str):
 		prefix = prefix.encode('utf-8')
 
-	setting = libcrypt.crypt_gensalt(prefix, rounds, None, 0)
+	setting: bytes | None = libcrypt.crypt_gensalt(prefix, rounds, None, 0)
 
 	if setting is None:
 		raise ValueError(f'crypt_gensalt() returned NULL for prefix {prefix!r} and rounds {rounds}')
 
-	return cast('bytes', setting)
+	return setting
 
 
 def crypt_yescrypt(plaintext: str) -> str:
@@ -60,9 +59,9 @@ def crypt_yescrypt(plaintext: str) -> str:
 	enc_plaintext = plaintext.encode('utf-8')
 	salt = crypt_gen_salt('$y$', rounds)
 
-	crypt_hash = libcrypt.crypt(enc_plaintext, salt)
+	crypt_hash: bytes | None = libcrypt.crypt(enc_plaintext, salt)
 
 	if crypt_hash is None:
 		raise ValueError('crypt() returned NULL')
 
-	return cast('bytes', crypt_hash).decode('utf-8')
+	return crypt_hash.decode('utf-8')

--- a/archinstoo/archinstoo/lib/general.py
+++ b/archinstoo/archinstoo/lib/general.py
@@ -30,7 +30,7 @@ def clear_vt100_escape_codes(data: bytes) -> bytes:
 	return re.sub(_VT100_ESCAPE_REGEX_BYTES, b'', data)
 
 
-def jsonify(obj: object, safe: bool = True) -> Any:
+def jsonify(obj: object, safe: bool = True) -> Any:  # noqa: ANN401 - dynamic JSON serializer
 	# Converts objects into json.dumps() compatible nested dictionaries.
 	# Setting safe to True skips dictionary keys starting with a bang (!)
 

--- a/archinstoo/archinstoo/lib/installer.py
+++ b/archinstoo/archinstoo/lib/installer.py
@@ -111,7 +111,7 @@ class Installer:
 		if accessibility_tools_in_use():
 			self._base_packages.extend(__accessibility_packages__)
 
-		self.post_base_install: list[Callable] = []  # type: ignore[type-arg]
+		self.post_base_install: list[Callable[..., None]] = []
 
 		self._modules: list[str] = []
 		self._binaries: list[str] = []

--- a/archinstoo/archinstoo/lib/menu/abstract_menu.py
+++ b/archinstoo/archinstoo/lib/menu/abstract_menu.py
@@ -17,7 +17,7 @@ class AbstractMenu[ValueT]:
 	def __init__(
 		self,
 		item_group: MenuItemGroup,
-		config: Any,
+		config: Any,  # noqa: ANN401 - menu config can be any type
 		auto_cursor: bool = True,
 		allow_reset: bool = False,
 		reset_warning: str | None = None,
@@ -32,7 +32,7 @@ class AbstractMenu[ValueT]:
 
 		self._sync_from_config()
 
-	def __enter__(self, *args: Any, **kwargs: Any) -> Self:
+	def __enter__(self, *args: Any, **kwargs: Any) -> Self:  # noqa: ANN401 - passthrough
 		return self
 
 	def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
@@ -133,7 +133,7 @@ class AbstractSubMenu[ValueT](AbstractMenu[ValueT]):
 	def __init__(
 		self,
 		item_group: MenuItemGroup,
-		config: Any,
+		config: Any,  # noqa: ANN401 - menu config can be any type
 		auto_cursor: bool = True,
 		allow_reset: bool = False,
 	):

--- a/archinstoo/archinstoo/lib/menu/list_manager.py
+++ b/archinstoo/archinstoo/lib/menu/list_manager.py
@@ -1,5 +1,5 @@
 import copy
-from typing import cast
+from typing import cast  # noqa: TID251 - generic menu value type
 
 from archinstoo.lib.menu.menu_helper import MenuHelper
 from archinstoo.lib.translationhandler import tr

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict, cast, override
+from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict, override
 
 if TYPE_CHECKING:
 	import builtins
@@ -690,14 +690,17 @@ class DeviceGeometry:
 
 	@property
 	def start(self) -> int:
-		return cast('int', self._geometry.start)
+		start: int = self._geometry.start
+		return start
 
 	@property
 	def end(self) -> int:
-		return cast('int', self._geometry.end)
+		end: int = self._geometry.end
+		return end
 
 	def get_length(self, unit: Unit = Unit.sectors) -> int:
-		return cast('int', self._geometry.getLength(unit.name))
+		length: int = self._geometry.getLength(unit.name)
+		return length
 
 	def table_data(self) -> dict[str, str | int]:
 		start = Size(self._geometry.start, Unit.sectors, self._sector_size)
@@ -741,9 +744,11 @@ class PartitionType(StrEnum):
 
 	def get_partition_code(self) -> int | None:
 		if self == PartitionType.PRIMARY:
-			return cast('int', parted.PARTITION_NORMAL)
+			normal: int = parted.PARTITION_NORMAL
+			return normal
 		if self == PartitionType.BOOT:
-			return cast('int', parted.PARTITION_BOOT)
+			boot: int = parted.PARTITION_BOOT
+			return boot
 		return None
 
 
@@ -1368,7 +1373,8 @@ class DeviceModification:
 		if self.wipe:
 			return partition_table.is_gpt()
 
-		return cast('bool', self.device.disk.type == PartitionTable.GPT.value)
+		is_gpt: bool = self.device.disk.type == PartitionTable.GPT.value
+		return is_gpt
 
 	def add_partition(self, partition: PartitionModification) -> None:
 		self.partitions.append(partition)

--- a/archinstoo/archinstoo/lib/models/mirrors.py
+++ b/archinstoo/archinstoo/lib/models/mirrors.py
@@ -4,13 +4,13 @@ import json
 import urllib.error
 import urllib.parse
 import urllib.request
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, NotRequired, Self, TypedDict, override
 
 from archinstoo.lib.models.packages import Repository
 from archinstoo.lib.output import debug
-from archinstoo.lib.utils.net import DownloadTimer, fetch_data_from_url, ping
+from archinstoo.lib.utils.net import DownloadTimer, ping
 
 
 def _parse_datetime(value: str | datetime.datetime | None) -> datetime.datetime | None:
@@ -23,6 +23,34 @@ def _parse_datetime(value: str | datetime.datetime | None) -> datetime.datetime 
 		return datetime.datetime.fromisoformat(value)
 	except ValueError, AttributeError:
 		return None
+
+
+class _MirrorStatusEntryV3Json(TypedDict):
+	# Schema of one entry in archlinux.org/mirrors/status/json/ (version 3).
+	url: str
+	protocol: str
+	active: bool
+	country: str
+	country_code: str
+	isos: bool
+	ipv4: bool
+	ipv6: bool
+	details: str
+	delay: NotRequired[int | None]
+	last_sync: NotRequired[str | None]
+	duration_avg: NotRequired[float | None]
+	duration_stddev: NotRequired[float | None]
+	completion_pct: NotRequired[float | None]
+	score: NotRequired[float | None]
+
+
+class _MirrorStatusListV3Json(TypedDict):
+	cutoff: int
+	last_check: str
+	num_checks: int
+	urls: list[_MirrorStatusEntryV3Json]
+	version: int
+	check_frequency: NotRequired[int]
 
 
 @dataclass
@@ -58,7 +86,7 @@ class MirrorStatusEntryV3:
 		debug(f'Loaded mirror {self._hostname}' + (f' with score {self.score}' if self.score else ''))
 
 	@classmethod
-	def from_dict(cls, data: dict[str, Any]) -> Self:
+	def from_dict(cls, data: _MirrorStatusEntryV3Json) -> Self:
 		return cls(
 			url=data['url'],
 			protocol=data['protocol'],
@@ -159,7 +187,7 @@ class MirrorStatusListV3:
 			raise ValueError('MirrorStatusListV3 only accepts version 3 data')
 
 	@classmethod
-	def from_dict(cls, data: dict[str, Any]) -> Self:
+	def from_dict(cls, data: _MirrorStatusListV3Json) -> Self:
 		if data.get('version') != 3:
 			raise ValueError('MirrorStatusListV3 only accepts version 3 data')
 
@@ -174,128 +202,6 @@ class MirrorStatusListV3:
 	@classmethod
 	def from_json(cls, data: str) -> Self:
 		return cls.from_dict(json.loads(data))
-
-	def to_json(self) -> str:
-		return json.dumps(
-			{
-				'cutoff': self.cutoff,
-				'last_check': self.last_check.isoformat(),
-				'num_checks': self.num_checks,
-				'urls': [asdict(u) for u in self.urls],
-				'version': self.version,
-			}
-		)
-
-
-@dataclass
-class ArchLinuxDeCountry:
-	code: str
-	name: str
-
-	@classmethod
-	def from_dict(cls, data: dict[str, Any]) -> Self:
-		return cls(code=data['code'], name=data['name'])
-
-
-@dataclass
-class ArchLinuxDeMirrorEntry:
-	url: str
-	host: str
-	country: ArchLinuxDeCountry | None = None
-	durationAvg: float | None = None
-	delay: int | None = None
-	durationStddev: float | None = None
-	completionPct: float | None = None
-	score: float | None = None
-	lastSync: datetime.datetime | None = None
-	ipv4: bool = True
-	ipv6: bool = False
-
-	@classmethod
-	def from_dict(cls, data: dict[str, Any]) -> Self:
-		return cls(
-			url=data['url'],
-			host=data['host'],
-			country=ArchLinuxDeCountry.from_dict(data['country']) if data.get('country') else None,
-			durationAvg=data.get('durationAvg'),
-			delay=data.get('delay'),
-			durationStddev=data.get('durationStddev'),
-			completionPct=data.get('completionPct'),
-			score=data.get('score'),
-			lastSync=_parse_datetime(data.get('lastSync')),
-			ipv4=data.get('ipv4', True),
-			ipv6=data.get('ipv6', False),
-		)
-
-	def to_v3_entry(self) -> dict[str, Any]:
-		# Convert to MirrorStatusEntryV3 compatible format
-		return {
-			'url': self.url,
-			'protocol': urllib.parse.urlparse(self.url).scheme,
-			'active': True,
-			'country': self.country.name if self.country else 'Worldwide',
-			'country_code': self.country.code if self.country else 'WW',
-			'isos': True,
-			'ipv4': self.ipv4,
-			'ipv6': self.ipv6,
-			'details': self.host,
-			'delay': self.delay,
-			'last_sync': self.lastSync,
-			'duration_avg': self.durationAvg,
-			'duration_stddev': self.durationStddev,
-			'completion_pct': self.completionPct,
-			'score': self.score,
-		}
-
-
-@dataclass
-class ArchLinuxDeMirrorList:
-	offset: int
-	limit: int
-	total: int
-	count: int
-	items: list[ArchLinuxDeMirrorEntry]
-
-	@classmethod
-	def from_dict(cls, data: dict[str, Any]) -> Self:
-		return cls(
-			offset=data['offset'],
-			limit=data['limit'],
-			total=data['total'],
-			count=data['count'],
-			items=[ArchLinuxDeMirrorEntry.from_dict(i) for i in data['items']],
-		)
-
-	@classmethod
-	def from_json(cls, data: str) -> Self:
-		return cls.from_dict(json.loads(data))
-
-	@classmethod
-	def fetch_all(cls, base_url: str) -> Self:
-		# Fetch all paginated results from archlinux.de API
-		limit = 100
-		first_page = cls.from_json(fetch_data_from_url(f'{base_url}?offset=0&limit={limit}'))
-		all_items = list(first_page.items)
-
-		for offset in range(limit, first_page.total, limit):
-			page = cls.from_json(fetch_data_from_url(f'{base_url}?offset={offset}&limit={limit}'))
-			all_items.extend(page.items)
-			debug(f'Fetched {len(all_items)}/{first_page.total} mirrors')
-
-		return cls(offset=0, limit=len(all_items), total=len(all_items), count=len(all_items), items=all_items)
-
-	def to_v3(self) -> MirrorStatusListV3:
-		# Convert to MirrorStatusListV3 format
-		urls = [item.to_v3_entry() for item in self.items]
-		return MirrorStatusListV3.from_dict(
-			{
-				'version': 3,
-				'cutoff': 3600,
-				'last_check': datetime.datetime.now(datetime.UTC),
-				'num_checks': 1,
-				'urls': urls,
-			}
-		)
 
 
 @dataclass

--- a/archinstoo/archinstoo/lib/models/mirrors.py
+++ b/archinstoo/archinstoo/lib/models/mirrors.py
@@ -25,7 +25,7 @@ def _parse_datetime(value: str | datetime.datetime | None) -> datetime.datetime 
 		return None
 
 
-class _MirrorStatusEntryV3Json(TypedDict):
+class _MirrorEntry(TypedDict):
 	# Schema of one entry in archlinux.org/mirrors/status/json/ (version 3).
 	url: str
 	protocol: str
@@ -44,11 +44,11 @@ class _MirrorStatusEntryV3Json(TypedDict):
 	score: NotRequired[float | None]
 
 
-class _MirrorStatusListV3Json(TypedDict):
+class _MirrorList(TypedDict):
 	cutoff: int
 	last_check: str
 	num_checks: int
-	urls: list[_MirrorStatusEntryV3Json]
+	urls: list[_MirrorEntry]
 	version: int
 	check_frequency: NotRequired[int]
 
@@ -86,7 +86,7 @@ class MirrorStatusEntryV3:
 		debug(f'Loaded mirror {self._hostname}' + (f' with score {self.score}' if self.score else ''))
 
 	@classmethod
-	def from_dict(cls, data: _MirrorStatusEntryV3Json) -> Self:
+	def from_dict(cls, data: _MirrorEntry) -> Self:
 		return cls(
 			url=data['url'],
 			protocol=data['protocol'],
@@ -187,7 +187,7 @@ class MirrorStatusListV3:
 			raise ValueError('MirrorStatusListV3 only accepts version 3 data')
 
 	@classmethod
-	def from_dict(cls, data: _MirrorStatusListV3Json) -> Self:
+	def from_dict(cls, data: _MirrorList) -> Self:
 		if data.get('version') != 3:
 			raise ValueError('MirrorStatusListV3 only accepts version 3 data')
 

--- a/archinstoo/archinstoo/lib/output.py
+++ b/archinstoo/archinstoo/lib/output.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeIs, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeIs, runtime_checkable
 
 if TYPE_CHECKING:
 	from collections.abc import Callable, Sequence
@@ -48,7 +48,8 @@ class FormattedOutput:
 			# if is invoked by name we restrict it to a method of the class. No need to mess more
 			if hasattr(o, class_formatter) and callable(getattr(o, class_formatter)):
 				func = getattr(o, class_formatter)
-				return cast('dict[str, Any]', func(filter_list))
+				formatted: dict[str, Any] = func(filter_list)
+				return formatted
 
 			raise ValueError('Unsupported formatting call')
 		if isinstance(o, _HasTableData):
@@ -57,7 +58,8 @@ class FormattedOutput:
 			return o.json()
 		if _is_dataclass_instance(o):
 			return asdict(o)
-		return cast('dict[str, Any]', getattr(o, '__dict__', {}))
+		obj_dict: dict[str, Any] = getattr(o, '__dict__', {})
+		return obj_dict
 
 	@classmethod
 	def as_table(

--- a/archinstoo/archinstoo/lib/pacman.py
+++ b/archinstoo/archinstoo/lib/pacman.py
@@ -73,7 +73,7 @@ class Pacman:
 			error(f'Keyring reset failed: {e}')
 			return False
 
-	def ask(self, error_message: str, bail_message: str, func: Callable, *args, **kwargs) -> None:  # type: ignore[no-untyped-def, type-arg]
+	def ask(self, error_message: str, bail_message: str, func: Callable[..., object], *args: object, **kwargs: object) -> None:
 		try:
 			func(*args, **kwargs)
 		except Exception as err:

--- a/archinstoo/archinstoo/lib/pm/mirrors.py
+++ b/archinstoo/archinstoo/lib/pm/mirrors.py
@@ -8,7 +8,6 @@ from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
 from archinstoo.lib.menu.list_manager import ListManager
 from archinstoo.lib.models.mirrors import (
 	PACMAN_OPTIONS,
-	ArchLinuxDeMirrorList,
 	CustomRepository,
 	CustomServer,
 	MirrorRegion,
@@ -496,7 +495,6 @@ class MirrorListHandler:
 
 		attempts = 3
 
-		# Try archlinux.org first
 		for attempt_nr in range(attempts):
 			try:
 				data = fetch_data_from_url('https://archlinux.org/mirrors/status/json/')
@@ -504,17 +502,6 @@ class MirrorListHandler:
 				return True
 			except Exception as e:
 				debug(f'Error fetching from archlinux.org: {e}')
-				time.sleep(attempt_nr + 1)
-
-		# Fallback to archlinux.de
-		for attempt_nr in range(attempts):
-			try:
-				de_list = ArchLinuxDeMirrorList.fetch_all('https://www.archlinux.de/api/mirrors')
-				v3_list = de_list.to_v3()
-				_MirrorCache.data.update(self._parse_remote_mirror_list(v3_list.to_json()))
-				return True
-			except Exception as e:
-				debug(f'Error fetching from archlinux.de: {e}')
 				time.sleep(attempt_nr + 1)
 
 		debug('Unable to fetch mirror list remotely, falling back to local mirror list')

--- a/archinstoo/archinstoo/lib/translationhandler.py
+++ b/archinstoo/archinstoo/lib/translationhandler.py
@@ -3,7 +3,7 @@ import gettext
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast, override
+from typing import cast, override  # noqa: TID251 - gettext runtime function
 
 
 @dataclass

--- a/archinstoo/archinstoo/lib/translationhandler.py
+++ b/archinstoo/archinstoo/lib/translationhandler.py
@@ -74,7 +74,12 @@ class TranslationHandler:
 		languages = Path.joinpath(locales_dir, self._languages)
 
 		with languages.open() as fp:
-			return cast('list[dict[str, str]]', json.load(fp))
+			data = json.load(fp)
+
+		if not isinstance(data, list) or not all(isinstance(entry, dict) for entry in data):
+			raise ValueError(f'Malformed {self._languages}: expected a JSON array of objects')
+
+		return data
 
 	def _get_catalog_size(self, translation: gettext.NullTranslations) -> int:
 		# Get the number of translated messages for a translations

--- a/archinstoo/archinstoo/lib/tui/curses_menu.py
+++ b/archinstoo/archinstoo/lib/tui/curses_menu.py
@@ -758,12 +758,15 @@ class SelectMenu[ValueT](AbstractCurses[ValueT]):
 
 		self._init_viewports(self._preview_size)
 
-		if self._menu_vp is None:
+		# read through a typed local: mypy can't see _init_viewports populate
+		# the attribute, so a direct self._menu_vp check reads as unreachable
+		menu_vp: Viewport | None = self._menu_vp
+		if menu_vp is None:
 			raise RuntimeError('SelectMenu _init_viewports did not set _menu_vp')
-		self._items_state: MenuItemsState = MenuItemsState(  # type: ignore[unreachable]
+		self._items_state: MenuItemsState = MenuItemsState(
 			self._item_group,
 			total_cols=self._horizontal_cols,
-			total_rows=self._menu_vp.height,
+			total_rows=menu_vp.height,
 			with_frame=self._frame is not None,
 		)
 

--- a/archinstoo/archinstoo/lib/tui/menu_item.py
+++ b/archinstoo/archinstoo/lib/tui/menu_item.py
@@ -28,7 +28,7 @@ class MenuItem:
 	_yes: ClassVar[Self | None] = None
 	_no: ClassVar[Self | None] = None
 
-	def get_value(self) -> Any:
+	def get_value(self) -> Any:  # noqa: ANN401 - menu value can be any type
 		if self.value is None:
 			raise RuntimeError(f'MenuItem {self.text!r} has no value')
 		return self.value
@@ -144,19 +144,19 @@ class MenuItemGroup:
 		for item in self.items:
 			item.preview_action = action
 
-	def set_focus_by_value(self, value: Any) -> None:
+	def set_focus_by_value(self, value: Any) -> None:  # noqa: ANN401 - menu value can be any type
 		for item in self._menu_items:
 			if item.value == value:
 				self.focus_item = item
 				break
 
-	def set_default_by_value(self, value: Any) -> None:
+	def set_default_by_value(self, value: Any) -> None:  # noqa: ANN401 - menu value can be any type
 		for item in self._menu_items:
 			if item.value == value:
 				self.default_item = item
 				break
 
-	def set_selected_by_value(self, values: Any | list[Any] | None) -> None:
+	def set_selected_by_value(self, values: Any | list[Any] | None) -> None:  # noqa: ANN401 - menu value can be any type
 		if values is None:
 			return
 

--- a/archinstoo/archinstoo/lib/tui/result.py
+++ b/archinstoo/archinstoo/lib/tui/result.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import cast
+from typing import cast  # noqa: TID251 - generic menu value type
 
 from .menu_item import MenuItem
 

--- a/archinstoo/archinstoo/lib/utils/net.py
+++ b/archinstoo/archinstoo/lib/utils/net.py
@@ -5,7 +5,7 @@ import socket
 import ssl
 import struct
 import time
-from typing import TYPE_CHECKING, Self, cast
+from typing import TYPE_CHECKING, Self
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -13,6 +13,7 @@ from urllib.request import urlopen
 from archinstoo.lib.exceptions import DownloadTimeout
 
 if TYPE_CHECKING:
+	from collections.abc import Callable
 	from types import FrameType, TracebackType
 
 
@@ -68,7 +69,7 @@ class DownloadTimer:
 		self.time: float | None = None
 		self.start_time: float | None = None
 		self.timeout = timeout
-		self.previous_handler = None
+		self.previous_handler: Callable[[int, FrameType | None], object] | int | signal.Handlers | None = None
 		self.previous_timer: int | None = None
 
 	def raise_timeout(self, _signl: int, _frame: FrameType | None) -> None:
@@ -77,7 +78,7 @@ class DownloadTimer:
 
 	def __enter__(self) -> Self:
 		if self.timeout > 0:
-			self.previous_handler = signal.signal(signal.SIGALRM, self.raise_timeout)  # type: ignore[assignment]
+			self.previous_handler = signal.signal(signal.SIGALRM, self.raise_timeout)
 			self.previous_timer = signal.alarm(self.timeout)
 
 		self.start_time = time.monotonic()
@@ -120,8 +121,8 @@ def fetch_data_from_url(url: str, params: dict[str, str] | None = None, timeout:
 
 	try:
 		response = urlopen(full_url, context=ssl_context, timeout=timeout)  # noqa: S310 - scheme restricted above
-		data = response.read().decode('UTF-8')
-		return cast('str', data)
+		data: str = response.read().decode('UTF-8')
+		return data
 	except URLError as e:
 		raise ValueError(f'Unable to fetch data from url: {url}\n{e}')
 	except Exception as e:

--- a/archinstoo/pyproject.toml
+++ b/archinstoo/pyproject.toml
@@ -173,6 +173,7 @@ docstring-code-format = true
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins
+    "ANN401", # any-type in signatures
     "ASYNC",  # flake8-async
     "B",      # flake8-bugbear
     "C4",     # flake8-comprehensions
@@ -207,6 +208,7 @@ select = [
     "SLOT",   # flake8-slot
     "T10",    # flake8-debugger
     "TC",     # flake8-type-checking
+    "TID251", # banned-api (typing.cast)
     "TID252", # relative-imports
     "UP",     # pyupgrade
     "W",      # pycodestyle warnings
@@ -239,6 +241,9 @@ max-complexity = 40
 
 [tool.ruff.lint.isort]
 known-first-party = ["archinstoo"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.cast".msg = "avoid cast(); annotate the binding or validate at the boundary (add # noqa: TID251 with a reason if truly needed)"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402"] # init hacks are standard.

--- a/archinstoo/tests/test_mirrors.py
+++ b/archinstoo/tests/test_mirrors.py
@@ -1,0 +1,48 @@
+import datetime
+import json
+
+from archinstoo.lib.models.mirrors import MirrorStatusListV3
+
+# Minimal slice of archlinux.org/mirrors/status/json/ (version 3)
+_ORG_JSON = json.dumps(
+	{
+		'cutoff': 86400,
+		'last_check': '2026-06-08T10:00:00Z',
+		'num_checks': 1,
+		'version': 3,
+		'urls': [
+			{
+				'url': 'https://mirror.example.org/archlinux/',
+				'protocol': 'https',
+				'active': True,
+				'country': 'Germany',
+				'country_code': 'DE',
+				'isos': True,
+				'ipv4': True,
+				'ipv6': False,
+				'details': 'https://mirror.example.org/',
+				'delay': 1200,
+				'last_sync': '2026-06-08T09:30:00Z',
+				'duration_avg': 0.5,
+				'duration_stddev': 0.1,
+				'completion_pct': 1.0,
+				'score': 1.7,
+			},
+		],
+	}
+)
+
+
+def test_mirror_status_v3_from_json() -> None:
+	status = MirrorStatusListV3.from_json(_ORG_JSON)
+
+	assert status.version == 3
+	assert len(status.urls) == 1
+
+	entry = status.urls[0]
+	assert entry.url == 'https://mirror.example.org/archlinux/'
+	assert entry.country_code == 'DE'
+	# score is rounded in __post_init__
+	assert entry.score == 2
+	# ISO strings are parsed into datetimes at the boundary
+	assert isinstance(entry.last_sync, datetime.datetime)


### PR DESCRIPTION
Reduce usages of `cast | Any` 

cast 17→5, Any 8→2, type: ignore 11→7 
keep all intentional ones or explicitly add `# noqa: RULE - reason`

misc: remove dead `.de` mirrors, rename to `_MirrorEntry` + test fixture