### PR TITLE
feat(distros): support from Debian installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ uv.lock
 **.vscode/**
 /site
 archinstall/
+partstoob/

--- a/archinstoo/archinstoo/__init__.py
+++ b/archinstoo/archinstoo/__init__.py
@@ -158,15 +158,16 @@ def _prepare() -> int:
 		# note indent fully offlines installs should be possible
 		# instead of importing full handler use sys.argv directly
 		try:
-			# non-Arch hosts ship pacman but none of its config/keyring; build
+			# a foreign host ships pacman but none of its config/keyring; build
 			# it first (conf before keyring: pacman-key reads pacman.conf).
-			if Os.running_from_host() and not Os.running_from_arch():
+			foreign_host = Os.running_from_host() and not Os.running_from_arch()
+			if foreign_host:
 				pacman_conf()
 				keyring_init()
 			info('Fetching db...')
 			Pacman.run('-Sy', peek_output=True)
-			# python deps come from the host package manager off Arch
-			if (Os.running_from_arch() or not Os.running_from_host()) and (rc := _bootstrap()):
+			# python deps come from the host package manager on a foreign host
+			if not foreign_host and (rc := _bootstrap()):
 				return rc
 		except Exception as e:
 			error('Failed to prepare app.')

--- a/archinstoo/archinstoo/__init__.py
+++ b/archinstoo/archinstoo/__init__.py
@@ -72,6 +72,7 @@ from .lib import Pacman, output
 from .lib.checkpoints import _run_script, clean_cache
 from .lib.hardware import SysInfo
 from .lib.output import FormattedOutput, debug, error, info, log, logger, warn
+from .lib.pm.bootstrap import keyring_init, pacman_conf
 from .lib.tui.curses_menu import Tui
 from .lib.utils.env import Os, is_root, is_venv, kernel_info, reload_python
 from .lib.utils.net import ping
@@ -157,9 +158,15 @@ def _prepare() -> int:
 		# note indent fully offlines installs should be possible
 		# instead of importing full handler use sys.argv directly
 		try:
+			# non-Arch hosts ship pacman but none of its config/keyring; build
+			# it first (conf before keyring: pacman-key reads pacman.conf).
+			if Os.running_from_host() and not Os.running_from_arch():
+				pacman_conf()
+				keyring_init()
 			info('Fetching db...')
 			Pacman.run('-Sy', peek_output=True)
-			if rc := _bootstrap():
+			# python deps come from the host package manager off Arch
+			if (Os.running_from_arch() or not Os.running_from_host()) and (rc := _bootstrap()):
 				return rc
 		except Exception as e:
 			error('Failed to prepare app.')

--- a/archinstoo/archinstoo/lib/global_menu.py
+++ b/archinstoo/archinstoo/lib/global_menu.py
@@ -81,7 +81,8 @@ class GlobalMenu(AbstractMenu[None]):
 				text='Theme',
 				action=self._select_theme,
 				preview_action=self._prev_theme,
-				key='theme',  # session-only TUI theme, not persisted
+				# CONFIG_KEY prefix: session-only TUI theme, excluded from config sync
+				key=f'{CONFIG_KEY}_theme',
 			),
 			MenuItem.separator(),  # critical - assumed empty and mandatory
 			MenuItem(

--- a/archinstoo/archinstoo/lib/pm/bootstrap.py
+++ b/archinstoo/archinstoo/lib/pm/bootstrap.py
@@ -1,0 +1,109 @@
+import json
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+from compression.zstd import ZstdFile
+from pathlib import Path
+
+from archinstoo.lib.output import info
+
+# Sources we pull from when the host isn't Arch and ships pacman but no config.
+_MIRROR_STATUS_URL = 'https://archlinux.org/mirrors/status/json/'
+_PACMAN_CONF_URL = 'https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/raw/main/pacman.conf'
+_KEYRING_MIRROR = 'https://geo.mirror.pkgbuild.com/core/os/x86_64/'
+
+_PACMAN_CONF = Path('/etc/pacman.conf')
+_MIRRORLIST = Path('/etc/pacman.d/mirrorlist')
+_TRUSTDB = Path('/etc/pacman.d/gnupg/trustdb.gpg')
+_KEYRING_DIR = Path('/usr/share/pacman/keyrings')
+
+# pacman expects these to exist; a bare host that only ships the binary won't
+# have them, so we create them up front before writing any config.
+_PACMAN_DIRS = (
+	Path('/etc/pacman.d/gnupg'),
+	Path('/etc/pacman.d/hooks'),
+	Path('/var/lib/pacman'),
+	Path('/var/cache/pacman/pkg'),
+)
+
+
+def _fetch(url: str, timeout: int = 30) -> str:
+	with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - fixed https upstream URLs
+		return str(resp.read().decode('utf-8'))
+
+
+def _has_repos() -> bool:
+	# True only if pacman.conf already declares a real repo, not just [options].
+	if not _PACMAN_CONF.exists():
+		return False
+	return bool(re.search(r'^\[(?!options\b)[\w-]+\]', _PACMAN_CONF.read_text(), re.MULTILINE))
+
+
+def _build_mirrorlist() -> str:
+	info(f'Fetching mirror status from {_MIRROR_STATUS_URL}...')
+	data = json.loads(_fetch(_MIRROR_STATUS_URL, timeout=15))
+	# score < 100 drops dead/slow mirrors; lower is better in the status feed.
+	servers = [
+		f'Server = {m["url"]}$repo/os/$arch'
+		for m in data.get('urls', [])
+		if m.get('active') and m.get('protocol') in ('https', 'http') and m.get('score') is not None and m['score'] < 100
+	]
+	return '\n'.join(['# Arch mirrors fetched by archinstoo bootstrap', *servers]) + '\n'
+
+
+def pacman_conf() -> None:
+	# Give pacman a working config + mirrorlist on a non-Arch host. Must run
+	# before keyring_init(): pacman-key reads /etc/pacman.conf for its GPGDir.
+	for d in _PACMAN_DIRS:
+		d.mkdir(parents=True, exist_ok=True)
+
+	if _has_repos():
+		return
+
+	info('Configuring pacman for non-Arch host...')
+	_MIRRORLIST.write_text(_build_mirrorlist())
+
+	info(f'Fetching pacman.conf from {_PACMAN_CONF_URL}...')
+	conf = _fetch(_PACMAN_CONF_URL)
+	# DownloadUser = alpm doesn't exist off Arch; drop it so pacman can run.
+	conf = re.sub(r'^DownloadUser\s*=.*\n', '', conf, flags=re.MULTILINE)
+	_PACMAN_CONF.write_text(conf)
+
+
+def _latest_keyring_url() -> str:
+	page = _fetch(_KEYRING_MIRROR)
+	pkgs: list[str] = re.findall(r'href="(archlinux-keyring-[^"]+\.zst)"', page)
+	if not pkgs:
+		raise RuntimeError('archlinux-keyring package not found on mirror')
+	# Lexical sort tracks the version-date suffix, so last == newest.
+	return _KEYRING_MIRROR + sorted(pkgs)[-1]
+
+
+def keyring_init() -> None:
+	# Install + populate the Arch keyring so -Sy can verify signatures at the
+	# upstream default. No-op once the keyring and an initialised trustdb both
+	# exist: Debian ships the keyring files but never inits the trustdb.
+	if (_KEYRING_DIR / 'archlinux.gpg').exists() and _TRUSTDB.exists():
+		return
+
+	url = _latest_keyring_url()
+	info(f'Downloading keyring {url}...')
+	with tempfile.TemporaryDirectory() as tmp:
+		root = Path(tmp)
+		pkg = root / 'keyring.pkg.tar.zst'
+		urllib.request.urlretrieve(url, pkg)  # noqa: S310 - url is the geo mirror, https only
+
+		info('Extracting keyring...')
+		with ZstdFile(pkg) as raw, tarfile.open(fileobj=raw, mode='r|') as t:
+			t.extractall(root, filter='data')
+
+		_KEYRING_DIR.mkdir(parents=True, exist_ok=True)
+		for key in (root / 'usr/share/pacman/keyrings').iterdir():
+			shutil.copy2(key, _KEYRING_DIR / key.name)
+
+	info('Initialising pacman-key...')
+	subprocess.run(['pacman-key', '--init'], check=True)  # noqa: S607 - pacman-key from $PATH, fixed args
+	subprocess.run(['pacman-key', '--populate', '--populate-from', str(_KEYRING_DIR), 'archlinux'], check=True)  # noqa: S603, S607 - pacman-key from $PATH, fixed args

--- a/archinstoo/archinstoo/lib/pm/bootstrap.py
+++ b/archinstoo/archinstoo/lib/pm/bootstrap.py
@@ -1,7 +1,6 @@
 import json
 import re
 import shutil
-import subprocess
 import tarfile
 import tempfile
 import urllib.request
@@ -9,14 +8,16 @@ from compression.zstd import ZstdFile
 from pathlib import Path
 
 from archinstoo.lib.output import info
+from archinstoo.lib.pacman import Pacman
+from archinstoo.lib.pathnames import MIRRORLIST, PACMAN_CONF
+from archinstoo.lib.utils.net import fetch_data_from_url
 
 # Sources we pull from when the host isn't Arch and ships pacman but no config.
+# (_PACMAN_CONF_URL is the same upstream default lib.pacman.reset_conf resets to.)
 _MIRROR_STATUS_URL = 'https://archlinux.org/mirrors/status/json/'
 _PACMAN_CONF_URL = 'https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/raw/main/pacman.conf'
 _KEYRING_MIRROR = 'https://geo.mirror.pkgbuild.com/core/os/x86_64/'
 
-_PACMAN_CONF = Path('/etc/pacman.conf')
-_MIRRORLIST = Path('/etc/pacman.d/mirrorlist')
 _TRUSTDB = Path('/etc/pacman.d/gnupg/trustdb.gpg')
 _KEYRING_DIR = Path('/usr/share/pacman/keyrings')
 
@@ -30,27 +31,18 @@ _PACMAN_DIRS = (
 )
 
 
-def _fetch(url: str, timeout: int = 30) -> str:
-	with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - fixed https upstream URLs
-		return str(resp.read().decode('utf-8'))
-
-
 def _has_repos() -> bool:
 	# True only if pacman.conf already declares a real repo, not just [options].
-	if not _PACMAN_CONF.exists():
+	if not PACMAN_CONF.exists():
 		return False
-	return bool(re.search(r'^\[(?!options\b)[\w-]+\]', _PACMAN_CONF.read_text(), re.MULTILINE))
+	return bool(re.search(r'^\[(?!options\b)[\w-]+\]', PACMAN_CONF.read_text(), re.MULTILINE))
 
 
 def _build_mirrorlist() -> str:
 	info(f'Fetching mirror status from {_MIRROR_STATUS_URL}...')
-	data = json.loads(_fetch(_MIRROR_STATUS_URL, timeout=15))
-	# score < 100 drops dead/slow mirrors; lower is better in the status feed.
-	servers = [
-		f'Server = {m["url"]}$repo/os/$arch'
-		for m in data.get('urls', [])
-		if m.get('active') and m.get('protocol') in ('https', 'http') and m.get('score') is not None and m['score'] < 100
-	]
+	data = json.loads(fetch_data_from_url(_MIRROR_STATUS_URL, timeout=15))
+	# Emit every active http/https mirror; ranking happens later, not here.
+	servers = [f'Server = {m["url"]}$repo/os/$arch' for m in data.get('urls', []) if m.get('active') and m.get('protocol') in ('https', 'http')]
 	return '\n'.join(['# Arch mirrors fetched by archinstoo bootstrap', *servers]) + '\n'
 
 
@@ -64,17 +56,17 @@ def pacman_conf() -> None:
 		return
 
 	info('Configuring pacman for non-Arch host...')
-	_MIRRORLIST.write_text(_build_mirrorlist())
+	MIRRORLIST.write_text(_build_mirrorlist())
 
 	info(f'Fetching pacman.conf from {_PACMAN_CONF_URL}...')
-	conf = _fetch(_PACMAN_CONF_URL)
+	conf = fetch_data_from_url(_PACMAN_CONF_URL)
 	# DownloadUser = alpm doesn't exist off Arch; drop it so pacman can run.
 	conf = re.sub(r'^DownloadUser\s*=.*\n', '', conf, flags=re.MULTILINE)
-	_PACMAN_CONF.write_text(conf)
+	PACMAN_CONF.write_text(conf)
 
 
 def _latest_keyring_url() -> str:
-	page = _fetch(_KEYRING_MIRROR)
+	page = fetch_data_from_url(_KEYRING_MIRROR)
 	pkgs: list[str] = re.findall(r'href="(archlinux-keyring-[^"]+\.zst)"', page)
 	if not pkgs:
 		raise RuntimeError('archlinux-keyring package not found on mirror')
@@ -94,7 +86,8 @@ def keyring_init() -> None:
 	with tempfile.TemporaryDirectory() as tmp:
 		root = Path(tmp)
 		pkg = root / 'keyring.pkg.tar.zst'
-		urllib.request.urlretrieve(url, pkg)  # noqa: S310 - url is the geo mirror, https only
+		with urllib.request.urlopen(url, timeout=30) as resp, pkg.open('wb') as out:  # noqa: S310 - geo mirror, https only
+			shutil.copyfileobj(resp, out)
 
 		info('Extracting keyring...')
 		with ZstdFile(pkg) as raw, tarfile.open(fileobj=raw, mode='r|') as t:
@@ -105,5 +98,5 @@ def keyring_init() -> None:
 			shutil.copy2(key, _KEYRING_DIR / key.name)
 
 	info('Initialising pacman-key...')
-	subprocess.run(['pacman-key', '--init'], check=True)  # noqa: S607 - pacman-key from $PATH, fixed args
-	subprocess.run(['pacman-key', '--populate', '--populate-from', str(_KEYRING_DIR), 'archlinux'], check=True)  # noqa: S603, S607 - pacman-key from $PATH, fixed args
+	Pacman.run('--init', default_cmd='pacman-key', peek_output=True)
+	Pacman.run(f'--populate --populate-from {_KEYRING_DIR} archlinux', default_cmd='pacman-key', peek_output=True)

--- a/archinstoo/archinstoo/lib/utils/env.py
+++ b/archinstoo/archinstoo/lib/utils/env.py
@@ -37,6 +37,11 @@ class Os:
 		return ''
 
 	@staticmethod
+	def running_from_arch() -> bool:
+		# distinguishes an Arch host/ISO from a foreign host (Debian, Alpine, ...)
+		return Os.running_from_who() == 'arch'
+
+	@staticmethod
 	def locate_binary(name: str) -> str:
 		if path := which(name):
 			return path

--- a/archinstoo/archinstoo/scripts/format.py
+++ b/archinstoo/archinstoo/scripts/format.py
@@ -17,9 +17,8 @@ def show_menu(config: ArchConfig) -> None:
 		global_menu.disable_all()
 		global_menu.run(additional_title=' - Format mode')
 
-		global_menu.set_enabled('theme', True)
 		global_menu.set_enabled('disk_config', True)
-		global_menu.set_enabled('__config__', True)
+		global_menu.set_enabled('__config__', True)  # also enables session-only theme
 
 		global_menu.run()
 

--- a/archinstoo/archinstoo/scripts/packages.py
+++ b/archinstoo/archinstoo/scripts/packages.py
@@ -19,11 +19,10 @@ def show_menu(config: ArchConfig, args: Arguments) -> None:
 		global_menu.run(additional_title='- Pkgs mode')
 
 		# Only enable profile, applications, and packages
-		global_menu.set_enabled('theme', True)
 		global_menu.set_enabled('profile_config', True)
 		global_menu.set_enabled('app_config', True)
 		global_menu.set_enabled('packages', True)
-		global_menu.set_enabled('__config__', True)
+		global_menu.set_enabled('__config__', True)  # also enables session-only theme
 
 		# Skip mandatory checks
 		global_menu.set_mandatory('timezone', False)

--- a/distros/DEB
+++ b/distros/DEB
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Debian bootstrap for archinstoo. Mainly to test in docker.
+#
+# archinstoo needs python 3.14.
+
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+
+# shellcheck disable=SC2046
+apt-get install --no-install-recommends -y $(
+	awk '{print $1}' <<'EOF'
+    ca-certificates             # https support
+    python3.14                  # runtime
+    python3.14-venv             # venv + ensurepip for 3.14
+    python3.14-dev              # python headers (pyparted build)
+    libparted-dev               # libparted headers (pyparted build)
+    libcrypt-dev                # libcrypt.so symlink (crypt.py dlopen)
+    gcc                         # c compiler (pyparted build)
+    pacman-package-manager      # arch package manager
+    makepkg                     # pacman-key depends on makepkg utils
+    arch-install-scripts        # pacstrap, genfstab, etc
+    coreutils                   # gnu core utils
+    util-linux                  # lsblk, blkid, etc
+    pciutils                    # lspci
+    tzdata                      # timezone data
+    dosfstools                  # mkfs.fat
+    dmsetup                     # dm-* devices
+    e2fsprogs                   # mkfs.ext4
+    cryptsetup-bin              # luks
+    lvm2
+    btrfs-progs
+    f2fs-tools
+    xfsprogs                    # mkfs.xfs
+EOF
+)
+
+update-alternatives --install /usr/bin/python python /usr/bin/python3.14 1

--- a/distros/Dockerfile.debian
+++ b/distros/Dockerfile.debian
@@ -1,6 +1,6 @@
 FROM debian:forky-slim
 
-COPY DEB .
+COPY distros/DEB .
 RUN sh DEB
 
 COPY . .

--- a/distros/Dockerfile.debian
+++ b/distros/Dockerfile.debian
@@ -1,0 +1,10 @@
+FROM debian:forky-slim
+
+COPY DEB .
+RUN sh DEB
+
+COPY . .
+
+# RUN_VENV builds a 3.14 venv and pip-compiles pyparted (no apt pyparted for 3.14)
+ENTRYPOINT ["./RUN_VENV"]
+CMD ["--help"]


### PR DESCRIPTION
Adds `bootstrap` logic for when `pacman` is shipped without necessary files. 

* no-op on Arch/ISO:

`foreign_host = Os.running_from_host() and not Os.running_from_arch()` = Skip `__bootstrap()`  but init keyring and pacman conf instead. 
