### PR TITLE
feat(disk): add LUKS2 cipher selection

### DIFF
--- a/archinstoo/archinstoo/lib/disk/device_handler.py
+++ b/archinstoo/archinstoo/lib/disk/device_handler.py
@@ -13,6 +13,7 @@ from archinstoo.lib.models.device import (
 	BtrfsMountOption,
 	DeviceModification,
 	DiskEncryption,
+	EncryptionCipher,
 	FilesystemType,
 	LsblkInfo,
 	LuksPbkdf,
@@ -295,6 +296,7 @@ class DeviceHandler:
 		iter_time: int = DEFAULT_ITER_TIME,
 		pbkdf_memory: int | None = None,
 		pbkdf: LuksPbkdf = LuksPbkdf.Argon2id,
+		cipher: EncryptionCipher | None = None,
 	) -> Luks2:
 		luks_handler = Luks2(
 			dev_path,
@@ -302,7 +304,7 @@ class DeviceHandler:
 			password=enc_password,
 		)
 
-		key_file = luks_handler.encrypt(iter_time=iter_time, pbkdf_memory=pbkdf_memory, pbkdf=pbkdf)
+		key_file = luks_handler.encrypt(iter_time=iter_time, pbkdf_memory=pbkdf_memory, pbkdf=pbkdf, cipher=cipher)
 
 		self.udev_sync()
 
@@ -335,7 +337,12 @@ class DeviceHandler:
 			password=enc_conf.encryption_password,
 		)
 
-		key_file = luks_handler.encrypt(iter_time=iter_time or enc_conf.iter_time, pbkdf_memory=pbkdf_memory, pbkdf=enc_conf.pbkdf)
+		key_file = luks_handler.encrypt(
+			iter_time=iter_time or enc_conf.iter_time,
+			pbkdf_memory=pbkdf_memory,
+			pbkdf=enc_conf.pbkdf,
+			cipher=enc_conf.cipher,
+		)
 
 		self.udev_sync()
 

--- a/archinstoo/archinstoo/lib/disk/encryption_menu.py
+++ b/archinstoo/archinstoo/lib/disk/encryption_menu.py
@@ -8,6 +8,7 @@ from archinstoo.lib.models.device import (
 	DEFAULT_ITER_TIME,
 	DeviceModification,
 	DiskEncryption,
+	EncryptionCipher,
 	EncryptionType,
 	LuksPbkdf,
 	LvmConfiguration,
@@ -82,6 +83,14 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				dependencies=[self._check_dep_enc_type],
 				preview_action=self._preview,
 				key='iter_time',
+			),
+			MenuItem(
+				text='Encryption cipher',
+				action=select_cipher,
+				value=self._enc_config.cipher,
+				dependencies=[self._check_dep_enc_type],
+				preview_action=self._preview,
+				key='cipher',
 			),
 			MenuItem(
 				text='Partitions',
@@ -244,6 +253,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 		enc_password: Password | None = self._item_group.find_by_key('encryption_password').value
 		pbkdf: LuksPbkdf | None = self._item_group.find_by_key('pbkdf').value
 		iter_time: int | None = self._item_group.find_by_key('iter_time').value
+		cipher: EncryptionCipher | None = self._item_group.find_by_key('cipher').value
 		enc_partitions = self._item_group.find_by_key('partitions').value
 		enc_lvm_vols = self._item_group.find_by_key('lvm_volumes').value
 		auto_unlock_root: bool = self._item_group.find_by_key('auto_unlock_root').value or False
@@ -267,6 +277,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 				lvm_volumes=enc_lvm_vols,
 				iter_time=iter_time or DEFAULT_ITER_TIME,
 				pbkdf=pbkdf or LuksPbkdf.Argon2id,
+				cipher=cipher,
 				auto_unlock_root=auto_unlock_root,
 				tpm2_unlock=tpm2_unlock,
 				tpm2_pcrs=tpm2_pcrs,
@@ -288,6 +299,9 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if (iter_time := self._prev_iter_time()) is not None:
 			output += f'\n{iter_time}'
+
+		if (cipher := self._prev_cipher()) is not None:
+			output += f'\n{cipher}'
 
 		if (partitions := self._prev_partitions()) is not None:
 			output += f'\n\n{partitions}'
@@ -357,6 +371,15 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 
 		if iter_time and enc_type != EncryptionType.NO_ENCRYPTION:
 			return f'{"Iteration time"}: {iter_time}ms'
+
+		return None
+
+	def _prev_cipher(self) -> str | None:
+		cipher = self._item_group.find_by_key('cipher').value
+		enc_type = self._item_group.find_by_key('encryption_type').value
+
+		if cipher and enc_type != EncryptionType.NO_ENCRYPTION:
+			return f'{"Encryption cipher"}: {cipher.value}'
 
 		return None
 
@@ -500,7 +523,7 @@ def select_pbkdf(preset: LuksPbkdf | None = None) -> LuksPbkdf | None:
 	options = [LuksPbkdf.Argon2id, LuksPbkdf.Pbkdf2]
 	items = [MenuItem(o.display_name(), value=o) for o in options]
 	group = MenuItemGroup(items)
-	group.set_focus_by_value(preset.display_name())
+	group.set_focus_by_value(preset)
 
 	result = SelectMenu[LuksPbkdf](
 		group,
@@ -508,6 +531,30 @@ def select_pbkdf(preset: LuksPbkdf | None = None) -> LuksPbkdf | None:
 		allow_reset=True,
 		alignment=Alignment.CENTER,
 		frame=FrameProperties.min('Key derivation function'),
+	).run()
+
+	match result.type_:
+		case ResultType.Reset:
+			return None
+		case ResultType.Skip:
+			return preset
+		case ResultType.Selection:
+			return result.get_value()
+
+
+def select_cipher(preset: EncryptionCipher | None = None) -> EncryptionCipher | None:
+	# Skip keeps preset (incl. None = cryptsetup default), Reset clears to default.
+	items = [MenuItem(c.value, value=c) for c in EncryptionCipher]
+	group = MenuItemGroup(items)
+	if preset:
+		group.set_focus_by_value(preset)
+
+	result = SelectMenu[EncryptionCipher](
+		group,
+		allow_skip=True,
+		allow_reset=True,
+		alignment=Alignment.CENTER,
+		frame=FrameProperties.min('Encryption cipher'),
 	).run()
 
 	match result.type_:

--- a/archinstoo/archinstoo/lib/disk/filesystem.py
+++ b/archinstoo/archinstoo/lib/disk/filesystem.py
@@ -298,6 +298,7 @@ class FilesystemHandler:
 					lock_after_create,
 					iter_time=enc_config.iter_time,
 					pbkdf=enc_config.pbkdf,
+					cipher=enc_config.cipher,
 				)
 
 				enc_vols[vol] = luks_handler
@@ -338,6 +339,7 @@ class FilesystemHandler:
 						iter_time=iter_time,
 						pbkdf_memory=pbkdf_memory,
 						pbkdf=enc_config.pbkdf,
+						cipher=enc_config.cipher,
 					)
 
 					enc_mods[part_mod] = luks_handler

--- a/archinstoo/archinstoo/lib/disk/luks.py
+++ b/archinstoo/archinstoo/lib/disk/luks.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from archinstoo.lib.disk.utils import get_lsblk_info, umount
 from archinstoo.lib.exceptions import DiskError, SysCallError
 from archinstoo.lib.general import SysCommand, SysCommandWorker, run
-from archinstoo.lib.models.device import DEFAULT_ITER_TIME, LuksPbkdf
+from archinstoo.lib.models.device import DEFAULT_ITER_TIME, EncryptionCipher, LuksPbkdf
 from archinstoo.lib.output import debug, info
 
 if TYPE_CHECKING:
@@ -85,6 +85,7 @@ class Luks2:
 		key_file: Path | None = None,
 		pbkdf_memory: int | None = None,
 		pbkdf: LuksPbkdf = LuksPbkdf.Argon2id,
+		cipher: EncryptionCipher | None = None,
 	) -> Path | None:
 		debug(f'Luks2 encrypting: {self.luks_dev_path}')
 
@@ -92,6 +93,9 @@ class Luks2:
 
 		# pbkdf-memory is only relevant for argon2id
 		pbkdf_memory_arg = ['--pbkdf-memory', str(pbkdf_memory)] if pbkdf_memory and pbkdf == LuksPbkdf.Argon2id else []
+
+		# no --cipher => cryptsetup default (aes-xts-plain64)
+		cipher_arg = ['--cipher', cipher.value] if cipher else []
 
 		cmd = [
 			'cryptsetup',
@@ -108,6 +112,7 @@ class Luks2:
 			'--iter-time',
 			str(iter_time),
 			*pbkdf_memory_arg,
+			*cipher_arg,
 			*key_file_arg,
 			'--use-urandom',
 			'luksFormat',

--- a/archinstoo/archinstoo/lib/models/device.py
+++ b/archinstoo/archinstoo/lib/models/device.py
@@ -36,6 +36,14 @@ class LuksPbkdf(Enum):
 				return 'PBKDF2'
 
 
+class EncryptionCipher(Enum):
+	# None passed to cryptsetup means its built-in default (aes-xts-plain64).
+	# Adiantum/chacha20 are for CPUs without AES acceleration.
+	AES_XTS_PLAIN64 = 'aes-xts-plain64'
+	AES_ADIANTUM_PLAIN64 = 'aes-adiantum-plain64'
+	CHACHA20_RANDOM_PLAIN64 = 'chacha20-random-plain64'
+
+
 class DiskLayoutType(Enum):
 	Default = 'default-layout'
 	Manual = 'manual-partitioning'
@@ -1433,6 +1441,7 @@ class DiskEncryption:
 	lvm_volumes: list[LvmVolume] = field(default_factory=list)
 	iter_time: int = DEFAULT_ITER_TIME
 	pbkdf: LuksPbkdf = LuksPbkdf.Argon2id
+	cipher: EncryptionCipher | None = None
 	auto_unlock_root: bool = False
 	tpm2_unlock: bool = False
 	tpm2_pcrs: str = '0+7'


### PR DESCRIPTION
Cipher chosen as `EncryptionCipher` enum, threaded through the encrypt path alongside pbkdf; resolved to --cipher at the cryptsetup boundary. None = `cryptsetup` default (`aes-xts-plain64`). 

- enum + cipher field on `DiskEncryption` (no config serialization no persist encryption config)
- Encryption cipher menu item + `select_cipher` helper + preview
- fix: `select_pbkdf` passed `display_name()` str to `set_focus_by_value` where items hold the enum, so focus never set