### PR TITLE
fix(limine): keep kernels on FAT, limine reads FAT only

### DIFF
--- a/installer/archinstoo/lib/disk/layouts.py
+++ b/installer/archinstoo/lib/disk/layouts.py
@@ -41,8 +41,11 @@ def _boot_partition(
 	start = Size(1, Unit.MiB, sector_size)
 
 	if uefi:
-		# UEFI: ESP, mount at /efi for btrfs subvolumes so /boot stays in @
-		mountpoint = Path('/efi') if using_subvolumes else Path('/boot')
+		# UEFI: ESP, mount at /efi for btrfs subvolumes so /boot stays in @.
+		# Limine is the exception: it reads FAT only, so leaving the kernels
+		# on the root filesystem makes them unreachable and it panics at boot.
+		esp_at_efi = using_subvolumes and bootloader != Bootloader.Limine
+		mountpoint = Path('/efi') if esp_at_efi else Path('/boot')
 		partitions.append(
 			PartitionModification(
 				status=ModificationStatus.CREATE,

--- a/installer/tests/test_limine_layout.py
+++ b/installer/tests/test_limine_layout.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from archinstoo.lib.disk.layouts import _boot_partition
+from archinstoo.lib.models.bootloader import Bootloader
+from archinstoo.lib.models.device import FilesystemType, PartitionFlag, SectorSize, Unit
+
+SECTOR = SectorSize(512, Unit.B)
+
+
+@pytest.mark.parametrize(
+	('bootloader', 'using_subvolumes', 'expected'),
+	[
+		# limine reads FAT only, so its kernels have to stay on the ESP even
+		# when subvolumes would otherwise move it to /efi
+		(Bootloader.Limine, True, '/boot'),
+		(Bootloader.Limine, False, '/boot'),
+		# everything else keeps /boot inside @ so grub.cfg is snapshotted
+		(Bootloader.Grub, True, '/efi'),
+		(Bootloader.Systemd, True, '/efi'),
+		(Bootloader.Refind, True, '/efi'),
+		(Bootloader.Grub, False, '/boot'),
+	],
+)
+def test_uefi_esp_mountpoint(bootloader: Bootloader, using_subvolumes: bool, expected: str) -> None:
+	parts = _boot_partition(
+		SECTOR,
+		using_gpt=True,
+		uefi=True,
+		bootloader=bootloader,
+		filesystem_type=FilesystemType.BTRFS,
+		using_subvolumes=using_subvolumes,
+	)
+	assert len(parts) == 1
+	assert parts[0].mountpoint == Path(expected)
+	assert parts[0].fs_type == FilesystemType.FAT32
+	assert PartitionFlag.ESP in parts[0].flags
+
+
+def test_bios_limine_boot_stays_fat() -> None:
+	# the BIOS branch already carried this rule; pin it alongside the UEFI one
+	parts = _boot_partition(
+		SECTOR,
+		using_gpt=True,
+		uefi=False,
+		bootloader=Bootloader.Limine,
+		filesystem_type=FilesystemType.BTRFS,
+	)
+	boot = next(p for p in parts if p.mountpoint == Path('/boot'))
+	assert boot.fs_type == FilesystemType.FAT32


### PR DESCRIPTION
* guided UEFI+btrfs mounted the ESP at /efi so /boot stayed in @, but limine supports FAT12/16/32 and ISO9660 only ==> installed fine, then PANIC'd at boot with "Failed to open kernel", on the graphical console so serial showed nothing
* layouts.py already applied the FAT rule for BIOS, not for UEFI
* ESP stays at /boot for limine ==> kernels land on the ESP it can read, which is the layout upstream limine documents
* VM: /efi+btrfs panicked before, ESP-at-/boot+btrfs boots after

Assisted-By: Flint