### PR TITLE
ref(tui): prompt_choice for every plain single pick

### DIFF
--- a/installer/archinstoo/lib/applications/application_menu.py
+++ b/installer/archinstoo/lib/applications/application_menu.py
@@ -34,7 +34,7 @@ from archinstoo.lib.models.application import (
 )
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -307,26 +307,10 @@ class DevelopmentMenu(AbstractSubMenu[DevelopmentConfiguration]):
 
 
 def select_power_management(preset: PowerManagementConfiguration | None = None) -> PowerManagementConfiguration | None:
-	group = MenuItemGroup.from_enum(PowerManagement)
-
-	if preset:
-		group.set_focus_by_value(preset.power_management)
-
-	result = SelectMenu[PowerManagement](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('Power management'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return PowerManagementConfiguration(power_management=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(
+		MenuItemGroup.from_enum(PowerManagement), preset.power_management if preset else None, frame='Power management', allow_reset=True
+	)
+	return PowerManagementConfiguration(choice) if choice else None
 
 
 def select_cpu_scheduler(preset: CPUSchedulerConfiguration | None = None) -> CPUSchedulerConfiguration | None:
@@ -334,26 +318,9 @@ def select_cpu_scheduler(preset: CPUSchedulerConfiguration | None = None) -> CPU
 	items += [MenuItem(text=f'  {s.value}', value=s) for s in CPUScheduler if s not in EXPERIMENTAL_CPU_SCHEDULERS]
 	items.append(MenuItem(text='Experimental', read_only=True))
 	items += [MenuItem(text=f'  {s.value}', value=s) for s in CPUScheduler if s in EXPERIMENTAL_CPU_SCHEDULERS]
-	group = MenuItemGroup(items)
 
-	if preset:
-		group.set_focus_by_value(preset.scheduler)
-
-	result = SelectMenu[CPUScheduler](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('CPU scheduler'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return CPUSchedulerConfiguration(scheduler=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(items, preset.scheduler if preset else None, frame='CPU scheduler', allow_reset=True)
+	return CPUSchedulerConfiguration(choice) if choice else None
 
 
 def _enabled_text(label: str, enabled: bool) -> str:
@@ -378,49 +345,14 @@ def select_media_codecs(preset: MediaCodecsConfiguration | None) -> MediaCodecsC
 def select_audio(preset: AudioConfiguration | None = None) -> AudioConfiguration | None:
 	items = [MenuItem(a.value, value=a) for a in Audio]
 	items.append(MenuItem(text='None', value=None))
-	group = MenuItemGroup(items)
 
-	if preset:
-		group.set_focus_by_value(preset.audio)
-
-	result = SelectMenu[Audio](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Audio'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			audio = result.item().value
-			return AudioConfiguration(audio=audio) if audio else None
-		case ResultType.Reset:
-			raise ValueError('Unhandled result type')
+	choice = prompt_choice(items, preset.audio if preset else None, frame='Audio')
+	return AudioConfiguration(choice) if choice else None
 
 
 def select_firewall(preset: FirewallConfiguration | None = None) -> FirewallConfiguration | None:
-	group = MenuItemGroup.from_enum(Firewall)
-
-	if preset:
-		group.set_focus_by_value(preset.firewall)
-
-	result = SelectMenu[Firewall](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('Firewall'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return FirewallConfiguration(firewall=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(MenuItemGroup.from_enum(Firewall), preset.firewall if preset else None, frame='Firewall', allow_reset=True)
+	return FirewallConfiguration(choice) if choice else None
 
 
 def select_management(preset: ManagementConfiguration | None = None) -> ManagementConfiguration | None:
@@ -453,79 +385,21 @@ def select_management(preset: ManagementConfiguration | None = None) -> Manageme
 
 
 def select_monitor(preset: MonitorConfiguration | None = None) -> MonitorConfiguration | None:
-	group = MenuItemGroup.from_enum(Monitor)
-
-	if preset:
-		group.set_focus_by_value(preset.monitor)
-
-	result = SelectMenu[Monitor](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('Monitor'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return MonitorConfiguration(monitor=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(MenuItemGroup.from_enum(Monitor), preset.monitor if preset else None, frame='Monitor', allow_reset=True)
+	return MonitorConfiguration(choice) if choice else None
 
 
 def select_editor(preset: EditorConfiguration | None = None) -> EditorConfiguration | None:
-	group = MenuItemGroup.from_enum(Editor)
-
-	if preset:
-		group.set_focus_by_value(preset.editor)
-
 	header = 'Set an editor globally through /etc/environment?' + '\n'
-
-	result = SelectMenu[Editor](
-		group,
-		header=header,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('Editor'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return EditorConfiguration(editor=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(MenuItemGroup.from_enum(Editor), preset.editor if preset else None, header=header, frame='Editor', allow_reset=True)
+	return EditorConfiguration(choice) if choice else None
 
 
 def select_terminal(preset: TerminalConfiguration | None = None) -> TerminalConfiguration | None:
-	group = MenuItemGroup.from_enum(Terminal)
-
-	if preset:
-		group.set_focus_by_value(preset.terminal)
-
 	header = 'Set a terminal globally through /etc/environment?' + '\n'
 	header += 'Window manager profiles bind it too (foot is Wayland only)' + '\n'
-
-	result = SelectMenu[Terminal](
-		group,
-		header=header,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		allow_reset=True,
-		frame=FrameProperties.min('Terminal'),
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return TerminalConfiguration(terminal=result.get_value())
-		case ResultType.Reset:
-			return None
+	choice = prompt_choice(MenuItemGroup.from_enum(Terminal), preset.terminal if preset else None, header=header, frame='Terminal', allow_reset=True)
+	return TerminalConfiguration(choice) if choice else None
 
 
 def select_security(preset: SecurityConfiguration | None = None) -> SecurityConfiguration | None:

--- a/installer/archinstoo/lib/authentication/authentication_menu.py
+++ b/installer/archinstoo/lib/authentication/authentication_menu.py
@@ -4,11 +4,8 @@ from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
 from archinstoo.lib.models.authentication import AuthenticationConfiguration, PrivilegeEscalation
 from archinstoo.lib.models.users import Password, User
 from archinstoo.lib.output import FormattedOutput
-from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_yes_no
-from archinstoo.lib.tui.result import ResultType
-from archinstoo.lib.tui.types import Alignment, FrameProperties
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_yes_no
 
 from .password_prompt import get_password
 from .users_menu import select_users
@@ -108,23 +105,7 @@ def select_root_password(_preset: str | None = None) -> Password | None:
 def select_privilege_escalation(preset: PrivilegeEscalation | None) -> PrivilegeEscalation | None:
 	items = [MenuItem(method.value, value=method) for method in PrivilegeEscalation]
 	items.append(MenuItem(text='None', value=None))
-	group = MenuItemGroup(items)
-	group.set_selected_by_value(preset)
-
-	result = SelectMenu[PrivilegeEscalation | None](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Privilege escalation'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.item().value
-		case ResultType.Skip:
-			return preset
-		case _:
-			return PrivilegeEscalation.Sudo
+	return prompt_choice(items, preset, frame='Privilege escalation')
 
 
 def select_lock_root_account(preset: bool) -> bool:

--- a/installer/archinstoo/lib/authentication/users_menu.py
+++ b/installer/archinstoo/lib/authentication/users_menu.py
@@ -5,7 +5,7 @@ from archinstoo.lib.menu.list_manager import ListManager
 from archinstoo.lib.models.users import Shell, SupplementaryGroup, User
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text, prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -139,23 +139,7 @@ class UserList(ListManager[User]):
 def _select_shell(preset: Shell = Shell.BASH, elev: bool = False) -> Shell:
 	choices = [s for s in Shell if s != Shell.RBASH or not elev]
 	items = [MenuItem(s.value, value=s) for s in choices]
-	group = MenuItemGroup(items)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[Shell](
-		group,
-		allow_skip=True,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Shell'),
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			return Shell.BASH
+	return prompt_choice(items, preset, frame='Shell') or preset
 
 
 def _select_groups(preset: list[str] | None = None) -> list[str]:

--- a/installer/archinstoo/lib/bootloader/bootloader_menu.py
+++ b/installer/archinstoo/lib/bootloader/bootloader_menu.py
@@ -4,11 +4,8 @@ from typing import override
 from archinstoo.lib.hardware import SysInfo
 from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
 from archinstoo.lib.models.bootloader import Bootloader, BootloaderConfiguration
-from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text, prompt_yes_no
-from archinstoo.lib.tui.result import ResultType
-from archinstoo.lib.tui.types import Alignment, FrameProperties
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text, prompt_yes_no
 
 
 class BootloaderMenu(AbstractSubMenu[BootloaderConfiguration]):
@@ -242,22 +239,4 @@ def select_bootloader(preset: Bootloader | None, uefi: bool, skip_boot: bool = F
 
 	items = [MenuItem(o.display_name(), value=o) for o in options]
 	items.append(MenuItem(text='None', value=None))
-	group = MenuItemGroup(items)
-	group.set_default_by_value(default)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[Bootloader](
-		group,
-		header=header,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Bootloader'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return result.item().value
-		case ResultType.Reset:
-			raise ValueError('Unhandled result type')
+	return prompt_choice(items, preset, header=header, frame='Bootloader', default=default)

--- a/installer/archinstoo/lib/configuration.py
+++ b/installer/archinstoo/lib/configuration.py
@@ -109,7 +109,7 @@ class ConfigStore:
 	@classmethod
 	def prompt_resume(cls) -> dict[str, Any] | None:
 		# Prompt user to resume from saved config. Returns config dict or None.
-		from .tui.result import ResultType
+		from .tui.prompts import prompt_choice
 
 		if not cls.has_saved_config():
 			return None
@@ -119,24 +119,11 @@ class ConfigStore:
 				MenuItem(text='resume from saved', value='resume'),
 				MenuItem(text='start fresh', value='fresh'),
 			]
+			choice: str = prompt_choice(items, header='Saved configuration found:' + '\n', allow_skip=False)
 
-			group = MenuItemGroup(items)
-			group.focus_item = group.items[0]
-
-			result = SelectMenu[str](
-				group,
-				header='Saved configuration found:' + '\n',
-				alignment=Alignment.CENTER,
-				allow_skip=False,
-			).run()
-
-			if result.type_ == ResultType.Selection:
-				choice = result.get_value()
-
-				if choice == 'resume':
-					return cls.load_saved_config()
-				if choice == 'fresh':
-					cls.delete_saved_config()
+			if choice == 'resume':
+				return cls.load_saved_config()
+			cls.delete_saved_config()
 
 		return None
 

--- a/installer/archinstoo/lib/disk/disk_menu.py
+++ b/installer/archinstoo/lib/disk/disk_menu.py
@@ -17,10 +17,8 @@ from archinstoo.lib.models.device import (
 	SnapshotType,
 )
 from archinstoo.lib.output import FormattedOutput
-from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.result import ResultType
-from archinstoo.lib.tui.types import Alignment, FrameProperties
+from archinstoo.lib.tui.prompts import prompt_choice
 
 from .conf import select_disk_config, select_lvm_config
 
@@ -190,27 +188,9 @@ class DiskLayoutConfigurationMenu(AbstractSubMenu[DiskLayoutConfiguration]):
 	def _select_btrfs_snapshots(self, preset: SnapshotConfig | None) -> SnapshotConfig | None:
 		preset_type = preset.snapshot_type if preset else None
 
-		group = MenuItemGroup.from_enum(
-			SnapshotType,
-			sort_items=True,
-			preset=preset_type,
-		)
-
-		result = SelectMenu[SnapshotType](
-			group,
-			allow_reset=True,
-			allow_skip=True,
-			frame=FrameProperties.min('Snapshot type'),
-			alignment=Alignment.CENTER,
-		).run()
-
-		match result.type_:
-			case ResultType.Skip:
-				return preset
-			case ResultType.Reset:
-				return None
-			case ResultType.Selection:
-				return SnapshotConfig(snapshot_type=result.get_value())
+		group = MenuItemGroup.from_enum(SnapshotType, sort_items=True)
+		choice = prompt_choice(group, preset_type, frame='Snapshot type', allow_reset=True)
+		return SnapshotConfig(snapshot_type=choice) if choice else None
 
 	def _prev_disk_layouts(self, item: MenuItem) -> str | None:
 		if not item.value:

--- a/installer/archinstoo/lib/disk/encryption_menu.py
+++ b/installer/archinstoo/lib/disk/encryption_menu.py
@@ -21,7 +21,7 @@ from archinstoo.lib.models.device import (
 from archinstoo.lib.output import FormattedOutput
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text, prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -232,24 +232,7 @@ class DiskEncryptionMenu(AbstractSubMenu[DiskEncryption]):
 			return preset
 
 		group = MenuHelper(data=devices).create_menu_group()
-		if preset:
-			group.set_focus_by_value(preset)
-
-		result = SelectMenu[Fido2Device](
-			group,
-			header=header,
-			alignment=Alignment.CENTER,
-			allow_skip=True,
-			allow_reset=True,
-		).run()
-
-		match result.type_:
-			case ResultType.Reset:
-				return None
-			case ResultType.Skip:
-				return preset
-			case ResultType.Selection:
-				return result.get_value()
+		return prompt_choice(group, preset, header=header, allow_reset=True)
 
 	def _select_tpm2_unlock(self, preset: bool) -> bool:
 		prompt = 'Bind a TPM2 keyslot to the LUKS device(s) so the disk auto-unlocks at boot ?' + '\n'
@@ -456,27 +439,8 @@ def select_encryption_type(
 	if not preset:
 		preset = options[0]
 
-	preset_value = preset.type_to_text()
-
 	items = [MenuItem(o.type_to_text(), value=o) for o in options]
-	group = MenuItemGroup(items)
-	group.set_focus_by_value(preset_value)
-
-	result = SelectMenu[EncryptionType](
-		group,
-		allow_skip=True,
-		allow_reset=True,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Encryption type'),
-	).run()
-
-	match result.type_:
-		case ResultType.Reset:
-			return None
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return result.get_value()
+	return prompt_choice(items, preset, frame='Encryption type', allow_reset=True)
 
 
 def select_encrypted_password() -> Password | None:
@@ -554,48 +518,13 @@ def select_pbkdf(preset: LuksPbkdf | None = None) -> LuksPbkdf | None:
 		preset = LuksPbkdf.Argon2id
 
 	items = [MenuItem(o.display_name(), value=o) for o in LuksPbkdf]
-	group = MenuItemGroup(items)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[LuksPbkdf](
-		group,
-		allow_skip=True,
-		allow_reset=True,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Key derivation function'),
-	).run()
-
-	match result.type_:
-		case ResultType.Reset:
-			return None
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return result.get_value()
+	return prompt_choice(items, preset, frame='Key derivation function', allow_reset=True)
 
 
 def select_cipher(preset: EncryptionCipher | None = None) -> EncryptionCipher | None:
 	# Skip keeps preset (incl. None = cryptsetup default), Reset clears to default.
 	items = [MenuItem(c.value, value=c) for c in EncryptionCipher]
-	group = MenuItemGroup(items)
-	if preset:
-		group.set_focus_by_value(preset)
-
-	result = SelectMenu[EncryptionCipher](
-		group,
-		allow_skip=True,
-		allow_reset=True,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Encryption cipher'),
-	).run()
-
-	match result.type_:
-		case ResultType.Reset:
-			return None
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return result.get_value()
+	return prompt_choice(items, preset, frame='Encryption cipher', allow_reset=True)
 
 
 def select_iteration_time(preset: int | None = None) -> int | None:

--- a/installer/archinstoo/lib/disk/partitioning_menu.py
+++ b/installer/archinstoo/lib/disk/partitioning_menu.py
@@ -17,11 +17,8 @@ from archinstoo.lib.models.device import (
 	Unit,
 )
 from archinstoo.lib.output import FormattedOutput
-from archinstoo.lib.tui.curses_menu import SelectMenu
-from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_dir, prompt_text, prompt_yes_no
-from archinstoo.lib.tui.result import ResultType
-from archinstoo.lib.tui.types import Alignment, FrameProperties
+from archinstoo.lib.tui.menu_item import MenuItem
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_dir, prompt_text, prompt_yes_no
 
 from .layouts import suggest_disk_layout
 from .subvolume_menu import SubvolumeMenu
@@ -436,21 +433,7 @@ class PartitioningList(ListManager[DiskSegment]):
 	def _prompt_partition_fs_type(self, prompt: str | None = None) -> FilesystemType:
 		fs_types = filter(lambda fs: fs != FilesystemType.CRYPTO_LUKS, FilesystemType)
 		items = [MenuItem(fs.value, value=fs) for fs in fs_types]
-		group = MenuItemGroup(items, sort_items=False)
-
-		result = SelectMenu[FilesystemType](
-			group,
-			header=prompt,
-			alignment=Alignment.CENTER,
-			frame=FrameProperties.min('Filesystem'),
-			allow_skip=False,
-		).run()
-
-		match result.type_:
-			case ResultType.Selection:
-				return result.get_value()
-			case _:
-				raise ValueError('Unhandled result type')
+		return prompt_choice(items, header=prompt, frame='Filesystem', allow_skip=False)
 
 	def _validate_value(
 		self,

--- a/installer/archinstoo/lib/disk/selectors.py
+++ b/installer/archinstoo/lib/disk/selectors.py
@@ -9,6 +9,7 @@ from archinstoo.lib.models.device import (
 from archinstoo.lib.output import FormattedOutput
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
+from archinstoo.lib.tui.prompts import prompt_choice
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties, Orientation, PreviewStyle
 
@@ -70,21 +71,7 @@ def select_partition_table() -> PartitionTable:
 		MenuItem('GPT', value=PartitionTable.GPT),
 		MenuItem('MBR', value=PartitionTable.MBR),
 	]
-	group = MenuItemGroup(items, sort_items=False)
-	group.set_focus_by_value(default)
-
-	result = SelectMenu[PartitionTable](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Partition table'),
-		allow_skip=False,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case _:
-			raise ValueError('Unhandled result type')
+	return prompt_choice(items, default, frame='Partition table', allow_skip=False)
 
 
 def select_main_filesystem_format(advanced: bool = False, allow_lvm: bool = False) -> FilesystemType:
@@ -103,19 +90,7 @@ def select_main_filesystem_format(advanced: bool = False, allow_lvm: bool = Fals
 	if allow_lvm:
 		items.append(MenuItem('lvm', value=FilesystemType.LVM))
 
-	group = MenuItemGroup(items, sort_items=False)
-	result = SelectMenu[FilesystemType](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Filesystem'),
-		allow_skip=False,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case _:
-			raise ValueError('Unhandled result type')
+	return prompt_choice(items, frame='Filesystem', allow_skip=False)
 
 
 def select_mount_options() -> list[str]:

--- a/installer/archinstoo/lib/global_menu.py
+++ b/installer/archinstoo/lib/global_menu.py
@@ -9,7 +9,7 @@ from archinstoo.lib.profile.base import GreeterType, Profile, ProfileType
 from archinstoo.lib.tui.content_editor import edit_content
 from archinstoo.lib.tui.curses_menu import SelectMenu, Tui
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment
 
@@ -459,14 +459,7 @@ class GlobalMenu(AbstractMenu[None]):
 					MenuItem(text='Load optimized defaults', value='optimized'),
 				]
 
-				result = SelectMenu[str](
-					MenuItemGroup(items, sort_items=False),
-					header='Sysctl',
-					alignment=Alignment.CENTER,
-					allow_skip=True,
-				).run()
-
-				if result.type_ == ResultType.Selection and result.get_value() == 'optimized':
+				if prompt_choice(items, header='Sysctl') == 'optimized':
 					preset = self._sysctl_optimized_defaults()
 
 			current_text = '\n'.join(preset) if preset else ''
@@ -808,28 +801,15 @@ class GlobalMenu(AbstractMenu[None]):
 		items.append(MenuItem(text='exit delete selection', value='abort_only'))
 		items.append(MenuItem(text='cancel abort', value='cancel'))
 
-		group = MenuItemGroup(items)
-		group.focus_item = group.items[0]  # Focus on first option
+		choice: str = prompt_choice(items, header='Abort the installation? \n', allow_skip=False)
 
-		result = SelectMenu[str](
-			group,
-			header='Abort the installation? \n',
-			alignment=Alignment.CENTER,
-			allow_skip=False,
-		).run()
-
-		if result.type_ == ResultType.Selection:
-			choice = result.get_value()
-
-			if choice == 'save_abort':
-				# Sync current selections to config before saving
-				self.sync_all_to_config()
-				store = ConfigStore(self._arch_config)
-				store.save()
-				raise SystemExit(0)  # User-initiated abort is not an error
-			if choice == 'abort_only':
-				ConfigStore.delete_saved_config()
-				raise SystemExit(0)  # User-initiated abort is not an error
-			# If 'cancel', just return to menu
-
-		return
+		if choice == 'save_abort':
+			# Sync current selections to config before saving
+			self.sync_all_to_config()
+			store = ConfigStore(self._arch_config)
+			store.save()
+			raise SystemExit(0)  # User-initiated abort is not an error
+		if choice == 'abort_only':
+			ConfigStore.delete_saved_config()
+			raise SystemExit(0)  # User-initiated abort is not an error
+		# If 'cancel', just return to menu

--- a/installer/archinstoo/lib/interactions/general_conf.py
+++ b/installer/archinstoo/lib/interactions/general_conf.py
@@ -6,7 +6,7 @@ from archinstoo.lib.models.packages import AvailablePackage, PackageGroup
 from archinstoo.lib.pm import enrich_package_info, list_available_packages
 from archinstoo.lib.tui.curses_menu import EditMenu, SelectMenu, Tui
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text, prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties, PreviewStyle
 
@@ -41,25 +41,7 @@ def select_timezone(preset: str | None = None) -> str | None:
 	timezones = list_timezones()
 
 	items = [MenuItem(tz, value=tz) for tz in timezones]
-	group = MenuItemGroup(items, sort_items=True)
-	group.set_selected_by_value(preset)
-	group.set_default_by_value(default)
-
-	result = SelectMenu[str](
-		group,
-		allow_reset=True,
-		allow_skip=True,
-		frame=FrameProperties.min('Timezone'),
-		alignment=Alignment.CENTER,
-	).run()
-
-	match result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Reset:
-			return default
-		case ResultType.Selection:
-			return result.get_value()
+	return prompt_choice(items, preset, frame='Timezone', default=default, sort_items=True, allow_reset=True, reset=default)
 
 
 def select_additional_packages(preset: list[str] | None = None) -> list[str]:
@@ -233,17 +215,4 @@ def select_post_installation(elapsed_time: float | None = None) -> PostInstallat
 	header += '\nAfter reboot, remove the installation medium' + '\n'
 
 	items = [MenuItem(action.value, value=action) for action in PostInstallationAction]
-	group = MenuItemGroup(items)
-
-	result = SelectMenu[PostInstallationAction](
-		group,
-		header=header,
-		allow_skip=False,
-		alignment=Alignment.CENTER,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case _:
-			raise ValueError('Post installation action not handled')
+	return prompt_choice(items, header=header, allow_skip=False)

--- a/installer/archinstoo/lib/interactions/system_conf.py
+++ b/installer/archinstoo/lib/interactions/system_conf.py
@@ -11,7 +11,7 @@ from archinstoo.lib.models.kernel import DEFAULT_KERNEL, Kernel
 from archinstoo.lib.models.swap import SwapConfiguration, ZramAlgorithm
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -59,27 +59,11 @@ def select_swap(preset: SwapConfiguration | None = None) -> SwapConfiguration:
 	algo = preset.algorithm
 	recomp_algo: ZramAlgorithm | None = None
 	if zram:
-		# Ask for compression algorithm
-		algo_group = MenuItemGroup.from_enum(ZramAlgorithm, sort_items=False)
-		algo_group.set_default_by_value(ZramAlgorithm.Default)
-		algo_group.set_focus_by_value(preset.algorithm)
-
-		algo_result = SelectMenu[ZramAlgorithm](
-			algo_group,
-			header='Select zram compression algorithm:' + '\n',
-			alignment=Alignment.CENTER,
-			allow_skip=True,
-		).run()
-
-		match algo_result.type_:
-			case ResultType.Skip:
-				algo = preset.algorithm
-			case ResultType.Selection:
-				algo = algo_result.get_value()
-			case ResultType.Reset:
-				raise ValueError('Unhandled result type')
-			case _:
-				assert_never(algo_result.type_)
+		algo_group = MenuItemGroup.from_enum(ZramAlgorithm)
+		algo = (
+			prompt_choice(algo_group, preset.algorithm, header='Select zram compression algorithm:' + '\n', default=ZramAlgorithm.Default)
+			or preset.algorithm
+		)
 
 		# Ask for idle recompression algorithm (only if a specific primary algo was chosen)
 		if algo != ZramAlgorithm.Default:
@@ -168,24 +152,4 @@ def _select_recomp_algorithm(preset: ZramAlgorithm | None) -> ZramAlgorithm | No
 
 	# Exclude Default since recompression needs a specific algorithm
 	recomp_items = [MenuItem(algo.value, value=algo) for algo in ZramAlgorithm if algo != ZramAlgorithm.Default]
-	recomp_group = MenuItemGroup(recomp_items, sort_items=False)
-
-	if preset:
-		recomp_group.set_focus_by_value(preset)
-
-	recomp_result = SelectMenu[ZramAlgorithm](
-		recomp_group,
-		header=prompt,
-		alignment=Alignment.CENTER,
-		allow_skip=True,
-	).run()
-
-	match recomp_result.type_:
-		case ResultType.Skip:
-			return preset
-		case ResultType.Selection:
-			return recomp_result.get_value()
-		case ResultType.Reset:
-			raise ValueError('Unhandled result type')
-		case _:
-			assert_never(recomp_result.type_)
+	return prompt_choice(recomp_items, preset, header=prompt)

--- a/installer/archinstoo/lib/menu/locale_menu.py
+++ b/installer/archinstoo/lib/menu/locale_menu.py
@@ -15,6 +15,7 @@ from archinstoo.lib.menu.abstract_menu import AbstractSubMenu
 from archinstoo.lib.models.locale import LocaleConfiguration
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
+from archinstoo.lib.tui.prompts import prompt_choice
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -187,23 +188,7 @@ def select_locale_lang(preset: str | None = None) -> str | None:
 	locale_lang = {locale.split()[0] for locale in locales}
 
 	items = [MenuItem(ll, value=ll) for ll in locale_lang]
-	group = MenuItemGroup(items, sort_items=True)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[str](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Locale language'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			raise ValueError('Unhandled return type')
+	return prompt_choice(items, preset, frame='Locale language', sort_items=True)
 
 
 def select_locale_enc(sys_lang: str | None = None, preset: str | None = None) -> str | None:
@@ -212,46 +197,14 @@ def select_locale_enc(sys_lang: str | None = None, preset: str | None = None) ->
 	locale_enc = list_locale_encodings(sys_lang) if sys_lang else sorted({locale.split()[1] for locale in list_locales()})
 
 	items = [MenuItem(le, value=le) for le in locale_enc]
-	group = MenuItemGroup(items, sort_items=False)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[str](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Locale encoding'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			raise ValueError('Unhandled return type')
+	return prompt_choice(items, preset, frame='Locale encoding')
 
 
 def select_console_font(preset: str | None = None) -> str | None:
 	fonts = list_console_fonts()
 
 	items = [MenuItem(f, value=f) for f in fonts]
-	group = MenuItemGroup(items, sort_items=False)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[str](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Console font'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			raise ValueError('Unhandled return type')
+	return prompt_choice(items, preset, frame='Console font')
 
 
 def select_kb_layout(preset: str | None = None) -> str | None:
@@ -264,23 +217,7 @@ def select_kb_layout(preset: str | None = None) -> str | None:
 	sorted_kb_lang = sorted(kb_lang, key=lambda x: (len(x), x))
 
 	items = [MenuItem(lang, value=lang) for lang in sorted_kb_lang]
-	group = MenuItemGroup(items, sort_items=False)
-	group.set_focus_by_value(preset)
-
-	result = SelectMenu[str](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('Keyboard layout'),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			raise ValueError('Unhandled return type')
+	return prompt_choice(items, preset, frame='Keyboard layout')
 
 
 def _select_xkb_single(title: str, values: list[str], preset: str | None) -> str | None:
@@ -290,23 +227,8 @@ def _select_xkb_single(title: str, values: list[str], preset: str | None) -> str
 		return preset
 
 	items = [MenuItem('(none)', value=''), *(MenuItem(v, value=v) for v in values)]
-	group = MenuItemGroup(items, sort_items=False)
-	group.set_focus_by_value(preset or '')
-
-	result = SelectMenu[str](
-		group,
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min(title),
-		allow_skip=True,
-	).run()
-
-	match result.type_:
-		case ResultType.Selection:
-			return result.get_value()
-		case ResultType.Skip:
-			return preset
-		case _:
-			raise ValueError('Unhandled return type')
+	choice = prompt_choice(items, preset or '', frame=title)
+	return preset if choice is None else choice
 
 
 def select_xkb_layout(preset: str | None = None) -> str | None:

--- a/installer/archinstoo/lib/network/network_menu.py
+++ b/installer/archinstoo/lib/network/network_menu.py
@@ -1,13 +1,13 @@
 import ipaddress
 import re
-from typing import assert_never, override
+from typing import override
 
 from archinstoo.lib.menu.list_manager import ListManager
 from archinstoo.lib.models.network import DnsConfiguration, DnsProvider, MacAddressPolicy, NetworkConfiguration, Nic, NicType
 from archinstoo.lib.network.interfaces import list_interfaces
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text, prompt_yes_no
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text, prompt_yes_no
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -60,22 +60,7 @@ class ManualNetworkConfig(ListManager[Nic]):
 			return None
 
 		items = [MenuItem(i, value=i) for i in available]
-		group = MenuItemGroup(items, sort_items=True)
-
-		result = SelectMenu[str](
-			group,
-			alignment=Alignment.CENTER,
-			frame=FrameProperties.min('Interfaces'),
-			allow_skip=True,
-		).run()
-
-		match result.type_:
-			case ResultType.Skip:
-				return None
-			case ResultType.Selection:
-				return result.get_value()
-			case ResultType.Reset:
-				raise ValueError('Unhandled result type')
+		return prompt_choice(items, frame='Interfaces', sort_items=True)
 
 	def _get_ip_address(
 		self,
@@ -110,26 +95,7 @@ class ManualNetworkConfig(ListManager[Nic]):
 
 		header = f'Select which mode to configure for "{iface_name}"' + '\n'
 		items = [MenuItem(m, value=m) for m in modes]
-		group = MenuItemGroup(items, sort_items=True)
-		group.set_default_by_value(default_mode)
-
-		result = SelectMenu[str](
-			group,
-			header=header,
-			allow_skip=False,
-			alignment=Alignment.CENTER,
-			frame=FrameProperties.min('Modes'),
-		).run()
-
-		match result.type_:
-			case ResultType.Selection:
-				mode = result.get_value()
-			case ResultType.Reset:
-				raise ValueError('Unhandled result type')
-			case ResultType.Skip:
-				raise ValueError('The mode menu should not be skippable')
-			case _:
-				assert_never(result.type_)
+		mode = prompt_choice(items, header=header, frame='Modes', default=default_mode, sort_items=True, allow_skip=False)
 
 		if mode == 'IP (static)':
 			header = f'Enter the IP and subnet for {iface_name} (example: 192.168.0.5/24): ' + '\n'
@@ -228,18 +194,7 @@ def _select_dns(preset: DnsConfiguration | None) -> DnsConfiguration | None:
 
 def _select_mac_address(preset: MacAddressPolicy) -> MacAddressPolicy:
 	items = [MenuItem(m.display_msg(), value=m) for m in MacAddressPolicy]
-	group = MenuItemGroup(items)
-	group.set_selected_by_value(preset)
-
-	result = SelectMenu[MacAddressPolicy](
-		group,
-		header='MAC address randomization' + '\n',
-		alignment=Alignment.CENTER,
-		frame=FrameProperties.min('MAC address'),
-		allow_skip=True,
-	).run()
-
-	return result.get_value() if result.type_ == ResultType.Selection else preset
+	return prompt_choice(items, preset, header='MAC address randomization' + '\n', frame='MAC address') or preset
 
 
 def select_network(preset: NetworkConfiguration | None) -> NetworkConfiguration | None:

--- a/installer/archinstoo/lib/pm/mirrors.py
+++ b/installer/archinstoo/lib/pm/mirrors.py
@@ -23,7 +23,7 @@ from archinstoo.lib.pathnames import MIRRORLIST
 from archinstoo.lib.pm.config import set_parallel_downloads
 from archinstoo.lib.tui.curses_menu import SelectMenu, Tui
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
-from archinstoo.lib.tui.prompts import prompt_text
+from archinstoo.lib.tui.prompts import prompt_choice, prompt_text
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 from archinstoo.lib.utils.net import fetch_data_from_url
@@ -85,46 +85,14 @@ class CustomMirrorRepositoriesList(ListManager[CustomRepository]):
 		header += f'\n{"Url"}: {url}\n'
 		prompt = f'{header}\n' + 'Select signature check'
 
-		sign_chk_items = [MenuItem(s.value, value=s.value) for s in SignCheck]
-		group = MenuItemGroup(sign_chk_items, sort_items=False)
-
-		if preset is not None:
-			group.set_selected_by_value(preset.sign_check.value)
-
-		result = SelectMenu[SignCheck](
-			group,
-			header=prompt,
-			alignment=Alignment.CENTER,
-			allow_skip=False,
-		).run()
-
-		match result.type_:
-			case ResultType.Selection:
-				sign_check = SignCheck(result.get_value())
-			case _:
-				raise ValueError('Unhandled return type')
+		sign_chk_items = [MenuItem(s.value, value=s) for s in SignCheck]
+		sign_check = prompt_choice(sign_chk_items, preset.sign_check if preset else None, header=prompt, allow_skip=False)
 
 		header += f'{"Signature check"}: {sign_check.value}\n'
 		prompt = f'{header}\n' + 'Select signature option'
 
-		sign_opt_items = [MenuItem(s.value, value=s.value) for s in SignOption]
-		group = MenuItemGroup(sign_opt_items, sort_items=False)
-
-		if preset is not None:
-			group.set_selected_by_value(preset.sign_option.value)
-
-		result = SelectMenu(
-			group,
-			header=prompt,
-			alignment=Alignment.CENTER,
-			allow_skip=False,
-		).run()
-
-		match result.type_:
-			case ResultType.Selection:
-				sign_opt = SignOption(result.get_value())
-			case _:
-				raise ValueError('Unhandled return type')
+		sign_opt_items = [MenuItem(s.value, value=s) for s in SignOption]
+		sign_opt = prompt_choice(sign_opt_items, preset.sign_option if preset else None, header=prompt, allow_skip=False)
 
 		return CustomRepository(name, url, sign_check, sign_opt)
 

--- a/installer/archinstoo/lib/profile/profile_menu.py
+++ b/installer/archinstoo/lib/profile/profile_menu.py
@@ -10,6 +10,7 @@ from archinstoo.lib.profile.base import GreeterType, Profile, ProfileType
 from archinstoo.lib.profile.driver_select import select_driver
 from archinstoo.lib.tui.curses_menu import SelectMenu
 from archinstoo.lib.tui.menu_item import MenuItem, MenuItemGroup
+from archinstoo.lib.tui.prompts import prompt_choice
 from archinstoo.lib.tui.result import ResultType
 from archinstoo.lib.tui.types import Alignment, FrameProperties
 
@@ -226,7 +227,6 @@ def select_greeter(
 	if not profile or profile.is_greeter_supported():
 		items = [MenuItem(g.value, value=g) for g in GreeterType]
 		items.append(MenuItem(text='None', value=None))
-		group = MenuItemGroup(items, sort_items=True)
 
 		default: GreeterType | None = None
 		if preset is not None:
@@ -235,22 +235,7 @@ def select_greeter(
 			default_greeter = profile.default_greeter_type
 			default = default_greeter or None
 
-		group.set_default_by_value(default)
-
-		result = SelectMenu[GreeterType](
-			group,
-			allow_skip=True,
-			frame=FrameProperties.min('Greeter'),
-			alignment=Alignment.CENTER,
-		).run()
-
-		match result.type_:
-			case ResultType.Skip:
-				return preset
-			case ResultType.Selection:
-				return result.item().value
-			case ResultType.Reset:
-				raise ValueError('Unhandled result type')
+		return prompt_choice(items, preset, frame='Greeter', default=default, sort_items=True)
 
 	return None
 

--- a/installer/archinstoo/lib/tui/prompts.py
+++ b/installer/archinstoo/lib/tui/prompts.py
@@ -4,10 +4,77 @@ from typing import TYPE_CHECKING, Literal, overload
 from .curses_menu import EditMenu, SelectMenu
 from .menu_item import MenuItem, MenuItemGroup
 from .result import ResultType
-from .types import Alignment, Orientation
+from .types import Alignment, FrameProperties, Orientation
 
 if TYPE_CHECKING:
 	from collections.abc import Callable
+
+
+@overload
+def prompt_choice[T](
+	items: MenuItemGroup | list[MenuItem],
+	preset: T | None = ...,
+	*,
+	header: str | None = ...,
+	frame: str | None = ...,
+	default: T | None = ...,
+	sort_items: bool = ...,
+	allow_skip: Literal[False],
+	allow_reset: Literal[False] = ...,
+) -> T: ...
+@overload
+def prompt_choice[T](
+	items: MenuItemGroup | list[MenuItem],
+	preset: T | None = ...,
+	*,
+	header: str | None = ...,
+	frame: str | None = ...,
+	default: T | None = ...,
+	sort_items: bool = ...,
+	allow_skip: bool = ...,
+	allow_reset: bool = ...,
+	reset: T | None = ...,
+) -> T | None: ...
+
+
+def prompt_choice[T](
+	items: MenuItemGroup | list[MenuItem],
+	preset: T | None = None,
+	*,
+	header: str | None = None,
+	frame: str | None = None,
+	default: T | None = None,
+	sort_items: bool = False,
+	allow_skip: bool = True,
+	allow_reset: bool = False,
+	reset: T | None = None,
+) -> T | None:
+	# one pick. preset is where the cursor starts and what a skip hands back,
+	# reset is what a reset hands back, and an item carrying None comes back
+	# as None; so the caller reads the answer, not the result type
+	group = items if isinstance(items, MenuItemGroup) else MenuItemGroup(items, sort_items=sort_items)
+	if default is not None:
+		group.set_default_by_value(default)
+	if preset is not None:
+		group.set_focus_by_value(preset)
+
+	result = SelectMenu[T](
+		group,
+		header=header,
+		alignment=Alignment.CENTER,
+		frame=FrameProperties.min(frame) if frame else None,
+		allow_skip=allow_skip,
+		allow_reset=allow_reset,
+	).run()
+
+	match result.type_:
+		case ResultType.Skip:
+			return preset
+		case ResultType.Reset:
+			return reset
+		case ResultType.Selection:
+			value: T | None = result.item().value
+			return value
 
 
 @overload


### PR DESCRIPTION
* one helper in tui/prompts.py: items or a ready group, preset (cursor, and what a skip hands back), reset (what a reset hands back), default marker, frame, header. A None-valued item comes back as None, so the caller reads the answer, not the result type. Overloads give a bare value when neither skip nor reset is allowed
* 33 sites across 15 files converted; the unreachable Reset branches and 'Unhandled result type' raises they carried are gone
* select_encryption_type focused by display text against enum values, so the cursor never landed on the preset; it does now
* left alone: menus that branch on skip vs selection (disk config, LVM, network type, DNS provider), the two with preview panes (device, driver), the list-manager core, and the btrfs mount-option picker (two columns)

Assisted-By: Flint