### PR TITLE
feat(vm): guest agents per hypervisor with a vm_guest toggle

### DIFF
--- a/TVM
+++ b/TVM
@@ -53,6 +53,11 @@
 #                       without this. Needs the full module chain (vga-gl alone won't load):
 #                       qemu-hw-display-virtio-{gpu,gpu-gl,vga,vga-gl} + qemu-ui-opengl
 #   A2_QEMU_EXTRA       raw qemu args appended last (word-split, no quoting inside)
+#   A2_SPICE            'on' adds a SPICE server on 127.0.0.1:$A2_SPICE_PORT (default 5930)
+#                       plus the vdagent channel, so spice-vdagent in the guest has
+#                       something to talk to (clipboard, resolution, mouse). Connect with
+#                       remote-viewer spice://127.0.0.1:5930 (virt-viewer). Needs
+#                       qemu-ui-spice-core + qemu-chardev-spice on the host.
 #   A2_AUDIO_BACKEND    qemu -audiodev value (default 'pipewire'; 'pa'/'alsa' need the matching qemu-audio-* pkg)
 
 set -euo pipefail
@@ -79,6 +84,8 @@ A2_DISPLAY_BACKEND="${A2_DISPLAY_BACKEND:-gtk,zoom-to-fit=off}"
 A2_VGA="${A2_VGA:-std}"
 A2_GL="${A2_GL:-off}"
 A2_AUDIO_BACKEND="${A2_AUDIO_BACKEND:-pipewire}"
+A2_SPICE="${A2_SPICE:-off}"
+A2_SPICE_PORT="${A2_SPICE_PORT:-5930}"
 ARG="${1:-default}"
 
 OVMF_CODE=""
@@ -316,6 +323,25 @@ elif [ "$ATTACH_ISO" = "true" ]; then
 			-append "$(cat "$BOOT_DIR/cmdline") console=ttyS0,115200"
 		)
 	fi
+fi
+
+# SPICE server + vdagent virtio port: what the installed spice-vdagent binds to
+if [ "$A2_SPICE" = "on" ]; then
+	# -chardev help lists built-ins only, the spice chardev is a module: probe the option
+	# group. Captured, not piped: grep -q closing the pipe early trips pipefail.
+	spice_help="$(qemu-system-x86_64 -spice help 2>&1 || true)"
+	case "$spice_help" in
+	*"spice options"*) ;;
+	*) err "qemu has no SPICE support (install qemu-ui-spice-core and qemu-chardev-spice)" ;;
+	esac
+	# shellcheck disable=SC2054 # commas are qemu option syntax
+	QEMU_ARGS+=(
+		-spice "port=$A2_SPICE_PORT,addr=127.0.0.1,disable-ticketing=on"
+		-device virtio-serial
+		-chardev spicevmc,id=vdagent,name=vdagent
+		-device virtserialport,chardev=vdagent,name=com.redhat.spice.0
+	)
+	echo "SPICE on spice://127.0.0.1:$A2_SPICE_PORT (remote-viewer)"
 fi
 
 # raw qemu args, word-split: an extra disk with a serial, a second NIC, ...

--- a/installer/archinstoo/lib/args.py
+++ b/installer/archinstoo/lib/args.py
@@ -83,6 +83,7 @@ class ArchConfig:
 	kernel_headers: bool = False
 	firmware: FirmwareConfiguration = field(default_factory=FirmwareConfiguration.default)
 	ntp: bool = True
+	vm_guest: bool = True  # hypervisor guest tools when installing inside a VM
 	packages: list[str] = field(default_factory=list)
 	aur_packages: list[str] = field(default_factory=list)
 	timezone: str | None = None
@@ -110,6 +111,7 @@ class ArchConfig:
 			'network_config': self.network_config.json() if self.network_config else None,
 			'timezone': self.timezone,
 			'ntp': self.ntp,
+			'vm_guest': self.vm_guest,
 			'packages': self.packages,
 			'aur_packages': self.aur_packages,
 			'services': [s.json() if isinstance(s, UserService) else s for s in self.services],
@@ -169,6 +171,7 @@ class ArchConfig:
 		if firmware := args_config.get('firmware'):
 			arch_config.firmware = FirmwareConfiguration.parse_arg(firmware)
 		arch_config.ntp = args_config.get('ntp', True)
+		arch_config.vm_guest = args_config.get('vm_guest', True)
 
 		return arch_config
 

--- a/installer/archinstoo/lib/global_menu.py
+++ b/installer/archinstoo/lib/global_menu.py
@@ -25,6 +25,7 @@ from .interactions.general_conf import (
 	select_hostname,
 	select_ntp,
 	select_timezone,
+	select_vm_guest,
 )
 from .interactions.system_conf import select_firmware, select_kernel, select_swap
 from .menu.abstract_menu import CONFIG_KEY, AbstractMenu
@@ -189,6 +190,14 @@ class GlobalMenu(AbstractMenu[None]):
 				value=True,
 				preview_action=self._prev_ntp,
 				key='ntp',
+			),
+			MenuItem(
+				text='VM guest tools',
+				action=select_vm_guest,
+				value=True,
+				preview_action=self._prev_vm_guest,
+				dependencies=[SysInfo.is_vm],
+				key='vm_guest',
 			),
 			MenuItem(
 				text='Additional packages',
@@ -420,6 +429,11 @@ class GlobalMenu(AbstractMenu[None]):
 		if item.value:
 			return f'{"Timezone"}: {item.value}'
 		return None
+
+	def _prev_vm_guest(self, item: MenuItem) -> str | None:
+		if item.value is None:
+			return None
+		return f'Guest tools ({SysInfo.hypervisor() or "no hypervisor"}): {"Enabled" if item.value else "Disabled"}'
 
 	def _prev_ntp(self, item: MenuItem) -> str | None:
 		if item.value is not None:

--- a/installer/archinstoo/lib/hardware.py
+++ b/installer/archinstoo/lib/hardware.py
@@ -462,6 +462,15 @@ class _SysInfo:
 		return cards
 
 	@cached_property
+	def hypervisor(self) -> str:
+		# systemd-detect-virt's name (kvm, qemu, vmware, oracle, microsoft, ...), '' on bare metal
+		try:
+			name = b''.join(SysCommand('systemd-detect-virt')).decode().strip().lower()
+		except SysCallError, RequirementError:
+			return ''
+		return '' if name == 'none' else name
+
+	@cached_property
 	def is_vm(self) -> bool:
 		# Forks systemd-detect-virt, and gates the firmware scan, microcode and
 		# the gfx driver list. A host does not become a VM mid-run
@@ -668,6 +677,10 @@ class SysInfo:
 	@staticmethod
 	def is_vm() -> bool:
 		return _sys_info.is_vm
+
+	@staticmethod
+	def hypervisor() -> str:
+		return _sys_info.hypervisor
 
 	@staticmethod
 	def requires_sof_fw() -> bool:

--- a/installer/archinstoo/lib/installer.py
+++ b/installer/archinstoo/lib/installer.py
@@ -86,6 +86,18 @@ __ter_font_packages__ = ['terminus-font']
 # grub integration for either snapshot tool
 __grub_snapshot_packages__ = ['grub-btrfs', 'inotify-tools']
 __zram_packages__ = ['zram-generator']
+
+# guest integration per systemd-detect-virt name: packages, then the services they ship
+# https://github.com/archlinux/archinstall/issues/1476
+__vm_guest__: dict[str, tuple[list[str], list[str]]] = {
+	# both static units, udev starts them when their virtio-serial port shows up:
+	# guest-agent for host control, spice-vdagent for clipboard/resolution on a SPICE display
+	'kvm': (['qemu-guest-agent', 'spice-vdagent'], []),
+	'qemu': (['qemu-guest-agent', 'spice-vdagent'], []),
+	'vmware': (['open-vm-tools'], ['vmtoolsd', 'vmware-vmblock-fuse']),
+	'oracle': (['virtualbox-guest-utils'], ['vboxservice']),
+	'microsoft': (['hyperv'], ['hv_fcopy_daemon', 'hv_kvp_daemon', 'hv_vss_daemon']),
+}
 # what grimoire needs on the target before it can build anything from the AUR.
 # base-devel spelled out (its member list minus sudo) so a doas install does
 # not drag sudo in as a side effect of wanting a toolchain
@@ -1384,6 +1396,15 @@ class Installer:
 				# hibernation is an enhancement, not worth aborting a
 				# finished-installing system over (cf. allow_ssh)
 				warn(f'Failed to set up hibernation swap file: {err}')
+
+	def setup_vm_guest(self) -> None:
+		if not (guest := __vm_guest__.get(SysInfo.hypervisor())):
+			return
+		packages, services = guest
+		info(f'Installing {SysInfo.hypervisor()} guest integration: {", ".join(packages)}')
+		self.pacman.strap(packages)
+		if services:
+			self.enable_service(services)
 
 	def _setup_zram(self, algo: ZramAlgorithm, recomp_algo: ZramAlgorithm | None) -> None:
 		info('Setting up swap on zram')

--- a/installer/archinstoo/lib/interactions/general_conf.py
+++ b/installer/archinstoo/lib/interactions/general_conf.py
@@ -1,6 +1,7 @@
 import threading
 from enum import Enum
 
+from archinstoo.lib.hardware import SysInfo
 from archinstoo.lib.localization.utils import list_timezones
 from archinstoo.lib.models.packages import AvailablePackage, PackageGroup
 from archinstoo.lib.pm import enrich_package_info, list_available_packages
@@ -16,6 +17,12 @@ class PostInstallationAction(Enum):
 	REBOOT = 'reboot system'
 	POWEROFF = 'poweroff system'
 	CHROOT = 'chroot into install'
+
+
+def select_vm_guest(preset: bool = True) -> bool:
+	header = f'Install {SysInfo.hypervisor()} guest tools (agent, clipboard/time sync, shared folders)?\n'
+	choice = prompt_yes_no(header, preset)
+	return preset if choice is None else choice
 
 
 def select_ntp(preset: bool = True) -> bool:

--- a/installer/archinstoo/scripts/guided.py
+++ b/installer/archinstoo/scripts/guided.py
@@ -104,6 +104,9 @@ def perform_installation(
 		if config.swap and config.swap.enabled:
 			installation.setup_swap(config.swap)
 
+		if config.vm_guest:
+			installation.setup_vm_guest()
+
 		if config.sysctl:
 			installation.setup_sysctl(config.sysctl)
 

--- a/installer/examples/config_sample_full.json
+++ b/installer/examples/config_sample_full.json
@@ -303,6 +303,7 @@
     },
     "timezone": "Europe/Berlin",
     "ntp": true,
+    "vm_guest": true,
     "packages": [
         "syncthing",
         "chromium"
@@ -313,7 +314,11 @@
     "sysctl": [],
     "services": [
         "sshd",
-        {"unit": "syncthing.service", "user": "myuser", "linger": true}
+        {
+            "unit": "syncthing.service",
+            "user": "myuser",
+            "linger": true
+        }
     ],
     "custom_commands": [
         "#arch-chroot via bash tmp files # lines are ignored",

--- a/installer/tests/test_vm_guest.py
+++ b/installer/tests/test_vm_guest.py
@@ -1,0 +1,50 @@
+# Guest agents by hypervisor: kvm gets qemu-guest-agent, bare metal gets nothing.
+# https://github.com/archlinux/archinstall/issues/1476
+
+from types import SimpleNamespace
+
+import pytest
+
+from archinstoo.lib import installer as mod
+from archinstoo.lib.hardware import SysInfo
+from archinstoo.lib.installer import Installer
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, name: str) -> tuple[list[list[str]], list[list[str]]]:
+	strapped: list[list[str]] = []
+	enabled: list[list[str]] = []
+	monkeypatch.setattr(SysInfo, 'hypervisor', staticmethod(lambda: name))
+	inst = Installer.__new__(Installer)
+	inst.pacman = SimpleNamespace(strap=lambda pkgs: strapped.append(list(pkgs)))  # type: ignore[assignment]
+	monkeypatch.setattr(inst, 'enable_service', lambda svcs: enabled.append(list(svcs)), raising=False)
+	inst.setup_vm_guest()
+	return strapped, enabled
+
+
+def test_kvm_gets_qemu_guest_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+	# static unit, udev-activated: nothing to enable
+	assert _run(monkeypatch, 'kvm') == ([['qemu-guest-agent', 'spice-vdagent']], [])
+
+
+def test_hyperv_gets_all_three_daemons(monkeypatch: pytest.MonkeyPatch) -> None:
+	_, enabled = _run(monkeypatch, 'microsoft')
+	assert enabled == [['hv_fcopy_daemon', 'hv_kvp_daemon', 'hv_vss_daemon']]
+
+
+@pytest.mark.parametrize('name', ['', 'xen', 'parallels'])
+def test_unknown_or_bare_metal_does_nothing(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+	assert _run(monkeypatch, name) == ([], [])
+
+
+def test_every_map_entry_has_packages() -> None:
+	for name, (packages, _services) in mod.__vm_guest__.items():
+		assert packages, name
+
+
+def test_config_toggle_round_trip() -> None:
+	from archinstoo.lib.args import ArchConfig
+
+	assert ArchConfig().vm_guest is True
+	assert ArchConfig.from_config({'vm_guest': False}).vm_guest is False
+	assert ArchConfig.from_config({}).vm_guest is True
+	assert ArchConfig(vm_guest=False).safe_json()['vm_guest'] is False

--- a/isos/ISOMOD_CACHE_TEST.conf
+++ b/isos/ISOMOD_CACHE_TEST.conf
@@ -1,0 +1,2 @@
+# tiny cache profile for the file:// repo test (#3847)
+tree


### PR DESCRIPTION
* SysInfo.hypervisor() from systemd-detect-virt
* kvm/qemu: qemu-guest-agent + spice-vdagent (static units, udev-started)
* vmware: open-vm-tools; oracle: virtualbox-guest-utils; microsoft: hyperv
* `VM guest tools` menu item, only inside a VM; `vm_guest` config key, default on
* refs archlinux/archinstall#1476

Test matrix would need to test using other tools like VMWare, etc
Only tested using `remote-viewer`